### PR TITLE
feat(coa): UI for Allow Reconciliation and Account Currency (enter365#24)

### DIFF
--- a/src/api/useAccounts.ts
+++ b/src/api/useAccounts.ts
@@ -8,7 +8,11 @@ import type { components, paths } from './types'
 // Types
 // ============================================
 
-export type Account = components['schemas']['AccountResource']
+// Extended until OpenAPI types are regenerated with CoA parity fields
+export type Account = components['schemas']['AccountResource'] & {
+  allow_reconciliation?: boolean
+  currency?: string | null
+}
 
 export interface AccountFilters {
   page?: number
@@ -20,8 +24,14 @@ export interface AccountFilters {
 }
 
 // Use Scramble-generated request types directly
-export type CreateAccountData = components['schemas']['StoreAccountRequest']
-export type UpdateAccountData = components['schemas']['UpdateAccountRequest']
+export type CreateAccountData = components['schemas']['StoreAccountRequest'] & {
+  allow_reconciliation?: boolean
+  currency?: string | null
+}
+export type UpdateAccountData = components['schemas']['UpdateAccountRequest'] & {
+  allow_reconciliation?: boolean
+  currency?: string | null
+}
 
 export type AccountBalance = paths['/accounts/{account}/balance']['get']['responses']['200']['content']['application/json']
 export type AccountLedger = paths['/accounts/{account}/ledger']['get']['responses']['200']['content']['application/json']

--- a/src/pages/accounting/accounts/AccountDetailPage.vue
+++ b/src/pages/accounting/accounts/AccountDetailPage.vue
@@ -116,6 +116,18 @@ function viewJournalEntry(journalEntryId: number) {
               <span v-if="account.is_system" class="px-2.5 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400">
                 System Account
               </span>
+              <span
+                v-if="account.allow_reconciliation"
+                class="px-2.5 py-0.5 rounded text-xs font-medium bg-teal-100 text-teal-700 dark:bg-teal-900/30 dark:text-teal-400"
+              >
+                Reconcilable
+              </span>
+              <span
+                v-if="account.currency"
+                class="px-2.5 py-0.5 rounded text-xs font-medium bg-slate-100 text-slate-700 dark:bg-slate-700 dark:text-slate-300 font-mono"
+              >
+                {{ account.currency }}
+              </span>
             </div>
             <p v-if="account.description" class="mt-2 text-slate-600 dark:text-slate-400">
               {{ account.description }}
@@ -186,6 +198,18 @@ function viewJournalEntry(journalEntryId: number) {
               <dt class="text-slate-500 dark:text-slate-400">Opening Balance</dt>
               <dd class="font-medium text-slate-900 dark:text-slate-100">
                 {{ formatCurrency(account.opening_balance) }}
+              </dd>
+            </div>
+            <div class="flex justify-between">
+              <dt class="text-slate-500 dark:text-slate-400">Allow Reconciliation</dt>
+              <dd class="font-medium text-slate-900 dark:text-slate-100">
+                {{ account.allow_reconciliation ? 'Yes' : 'No' }}
+              </dd>
+            </div>
+            <div class="flex justify-between">
+              <dt class="text-slate-500 dark:text-slate-400">Account Currency</dt>
+              <dd class="font-medium text-slate-900 dark:text-slate-100 font-mono">
+                {{ account.currency || 'Company Default' }}
               </dd>
             </div>
             <div v-if="account.parent" class="flex justify-between">

--- a/src/pages/accounting/accounts/AccountFormPage.vue
+++ b/src/pages/accounting/accounts/AccountFormPage.vue
@@ -64,6 +64,16 @@ const typeOptions = [
   { value: 'expense', label: 'Beban (Expense)' },
 ]
 
+const currencyOptions = [
+  { value: '', label: 'Company Default' },
+  { value: 'IDR', label: 'IDR' },
+  { value: 'USD', label: 'USD' },
+  { value: 'EUR', label: 'EUR' },
+  { value: 'SGD', label: 'SGD' },
+  { value: 'JPY', label: 'JPY' },
+  { value: 'CNY', label: 'CNY' },
+]
+
 // Subtype options by type
 const subtypeOptions: Record<string, { value: string; label: string }[]> = {
   asset: [
@@ -110,6 +120,8 @@ const accountSchema = z.object({
     return val
   }),
   is_active: z.boolean().default(true),
+  allow_reconciliation: z.boolean().default(false),
+  currency: z.string().optional().nullable(),
   opening_balance: z.union([z.number(), z.string()]).default(0).transform(val => {
     if (typeof val === 'string') return parseFloat(val) || 0
     return val
@@ -129,6 +141,8 @@ const { values: form, errors, handleSubmit, setValues, setFieldValue, defineFiel
     description: '',
     parent_id: null,
     is_active: true,
+    allow_reconciliation: false,
+    currency: '',
     opening_balance: 0,
   },
 })
@@ -140,6 +154,8 @@ const [subtype] = defineField('subtype')
 const [description] = defineField('description')
 const [parentId] = defineField('parent_id')
 const [isActive] = defineField('is_active')
+const [allowReconciliation] = defineField('allow_reconciliation')
+const [currency] = defineField('currency')
 const [openingBalance] = defineField('opening_balance')
 
 // Watch for existing account data
@@ -153,6 +169,8 @@ watch(existingAccount, (account) => {
       description: account.description || '',
       parent_id: account.parent_id ? String(account.parent_id) : '',
       is_active: !!account.is_active,
+      allow_reconciliation: !!account.allow_reconciliation,
+      currency: account.currency || '',
       opening_balance: toNumber(account.opening_balance),
     })
   }
@@ -187,6 +205,8 @@ const onSubmit = handleSubmit(async (formValues) => {
       description: formValues.description || null,
       parent_id: formValues.parent_id ? parseInt(formValues.parent_id, 10) : null,
       is_active: formValues.is_active,
+      allow_reconciliation: formValues.allow_reconciliation,
+      currency: formValues.currency || null,
       opening_balance: formValues.opening_balance,
     }
 
@@ -336,6 +356,23 @@ const onSubmit = handleSubmit(async (formValues) => {
                   placeholder="Optional description for this account"
                 />
               </div>
+
+              <!-- Account Currency -->
+              <div>
+                <label class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
+                  Mata Uang Akun / Account Currency
+                </label>
+                <Select
+                  :model-value="currency || ''"
+                  test-id="account-currency"
+                  :options="currencyOptions"
+                  placeholder="Company Default"
+                  @update:model-value="(v) => setFieldValue('currency', v ? String(v) : '')"
+                />
+                <p class="mt-1 text-sm text-slate-500 dark:text-slate-400">
+                  Leave empty to use the company default currency
+                </p>
+              </div>
             </div>
           </Card>
 
@@ -369,19 +406,36 @@ const onSubmit = handleSubmit(async (formValues) => {
               <h2 class="font-semibold text-slate-900 dark:text-slate-100">Status</h2>
             </template>
 
-            <label class="flex items-center gap-3 cursor-pointer">
-              <input
-                v-model="isActive"
-                type="checkbox"
-                class="w-5 h-5 rounded border-slate-300 dark:border-slate-600 text-orange-500 focus:ring-orange-500"
-              />
-              <div>
-                <span class="font-medium text-slate-900 dark:text-slate-100">Active</span>
-                <p class="text-sm text-slate-500 dark:text-slate-400">
-                  Inactive accounts cannot be used in transactions
-                </p>
-              </div>
-            </label>
+            <div class="space-y-4">
+              <label class="flex items-center gap-3 cursor-pointer">
+                <input
+                  v-model="isActive"
+                  type="checkbox"
+                  class="w-5 h-5 rounded border-slate-300 dark:border-slate-600 text-orange-500 focus:ring-orange-500"
+                />
+                <div>
+                  <span class="font-medium text-slate-900 dark:text-slate-100">Active</span>
+                  <p class="text-sm text-slate-500 dark:text-slate-400">
+                    Inactive accounts cannot be used in transactions
+                  </p>
+                </div>
+              </label>
+
+              <label class="flex items-center gap-3 cursor-pointer">
+                <input
+                  v-model="allowReconciliation"
+                  type="checkbox"
+                  data-testid="account-allow-reconciliation"
+                  class="w-5 h-5 rounded border-slate-300 dark:border-slate-600 text-orange-500 focus:ring-orange-500"
+                />
+                <div>
+                  <span class="font-medium text-slate-900 dark:text-slate-100">Allow Reconciliation</span>
+                  <p class="text-sm text-slate-500 dark:text-slate-400">
+                    Izinkan rekonsiliasi — akun dapat dipilih di rekonsiliasi bank/partner
+                  </p>
+                </div>
+              </label>
+            </div>
           </Card>
 
           <!-- Account Code Guide -->

--- a/src/pages/accounting/accounts/AccountListPage.vue
+++ b/src/pages/accounting/accounts/AccountListPage.vue
@@ -234,8 +234,10 @@ function goToAccount(account: Account) {
       <!-- Header -->
       <div class="px-4 py-3 border-b border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800/50">
         <div class="grid grid-cols-12 gap-4 text-sm font-medium text-slate-500 dark:text-slate-400">
-          <div class="col-span-5">Account</div>
-          <div class="col-span-2">Type</div>
+          <div class="col-span-4">Account</div>
+          <div class="col-span-1">Type</div>
+          <div class="col-span-1 text-center">Currency</div>
+          <div class="col-span-1 text-center">Reconcile</div>
           <div class="col-span-2 text-right">Balance</div>
           <div class="col-span-1 text-center">Status</div>
           <div class="col-span-2 text-right">Actions</div>

--- a/src/pages/accounting/accounts/AccountTreeNode.vue
+++ b/src/pages/accounting/accounts/AccountTreeNode.vue
@@ -34,7 +34,7 @@ const isSystem = computed(() => !!props.account.is_system)
       @click="$emit('click', account)"
     >
       <!-- Account Name with Tree Indent -->
-      <div class="col-span-5 flex items-center gap-2" :style="{ paddingLeft: level * 24 + 'px' }">
+      <div class="col-span-4 flex items-center gap-2" :style="{ paddingLeft: level * 24 + 'px' }">
         <button
           v-if="hasChildren"
           class="p-0.5 rounded hover:bg-slate-200 dark:hover:bg-slate-700 transition-colors"
@@ -54,12 +54,29 @@ const isSystem = computed(() => !!props.account.is_system)
       </div>
 
       <!-- Type -->
-      <div class="col-span-2">
+      <div class="col-span-1">
         <span
           class="inline-flex px-2 py-0.5 rounded text-xs font-medium"
           :class="getAccountTypeColor(account.type)"
         >
           {{ getAccountTypeLabel(account.type) }}
+        </span>
+      </div>
+
+      <!-- Currency -->
+      <div class="col-span-1 text-center font-mono text-xs text-slate-600 dark:text-slate-400">
+        {{ account.currency || '—' }}
+      </div>
+
+      <!-- Allow Reconciliation -->
+      <div class="col-span-1 text-center">
+        <span
+          class="inline-flex px-2 py-0.5 rounded text-xs font-medium"
+          :class="account.allow_reconciliation
+            ? 'bg-teal-100 text-teal-700 dark:bg-teal-900/30 dark:text-teal-400'
+            : 'bg-slate-100 text-slate-500 dark:bg-slate-700 dark:text-slate-400'"
+        >
+          {{ account.allow_reconciliation ? 'Yes' : 'No' }}
         </span>
       </div>
 


### PR DESCRIPTION
## Summary
- Extends Account types with `allow_reconciliation` and `currency` until OpenAPI types are regenerated.
- Form: Allow Reconciliation checkbox + Account Currency select (IDR/USD/EUR/SGD/JPY/CNY or company default).
- Detail + list/tree columns show both fields.

Related to satriyop/enter365#24

## Test plan
- [ ] Open Bagan Akun list — Currency and Reconcile columns visible
- [ ] Create/edit account — set Allow Reconciliation and currency; save and verify on detail
- [ ] Empty currency submits as null (company default)