### PR TITLE
feat(coa): Import UI for Chart of Accounts (#25)

### DIFF
--- a/src/api/useAccounts.ts
+++ b/src/api/useAccounts.ts
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/vue-query'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/vue-query'
 import { computed, type Ref, type ComputedRef } from 'vue'
 import { createCrudHooks } from './factory'
 import { api, type PaginatedResponse } from './client'
@@ -135,6 +135,47 @@ export function useAccountLedger(
       return response.data || null
     },
     enabled: computed(() => !!accountId.value),
+  })
+}
+
+// ============================================
+// Import
+// ============================================
+
+export interface AccountImportError {
+  row: number
+  messages: string[]
+}
+
+export interface AccountImportResult {
+  created_count: number
+  error_count: number
+  errors: AccountImportError[]
+  accounts: Account[]
+}
+
+/**
+ * Import Chart of Accounts from CSV/XLSX
+ */
+export function useImportAccounts() {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (file: File) => {
+      const formData = new FormData()
+      formData.append('file', file)
+      const response = await api.post<{ message: string; data: AccountImportResult }>(
+        '/accounts/import',
+        formData,
+        {
+          headers: { 'Content-Type': 'multipart/form-data' },
+        }
+      )
+      return response.data
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['accounts'] })
+    },
   })
 }
 

--- a/src/api/useAccounts.ts
+++ b/src/api/useAccounts.ts
@@ -8,7 +8,11 @@ import type { components, paths } from './types'
 // Types
 // ============================================
 
-export type Account = components['schemas']['AccountResource']
+// Extended until OpenAPI types are regenerated with CoA parity fields
+export type Account = components['schemas']['AccountResource'] & {
+  allow_reconciliation?: boolean
+  currency?: string | null
+}
 
 export interface AccountFilters {
   page?: number
@@ -20,8 +24,14 @@ export interface AccountFilters {
 }
 
 // Use Scramble-generated request types directly
-export type CreateAccountData = components['schemas']['StoreAccountRequest']
-export type UpdateAccountData = components['schemas']['UpdateAccountRequest']
+export type CreateAccountData = components['schemas']['StoreAccountRequest'] & {
+  allow_reconciliation?: boolean
+  currency?: string | null
+}
+export type UpdateAccountData = components['schemas']['UpdateAccountRequest'] & {
+  allow_reconciliation?: boolean
+  currency?: string | null
+}
 
 export type AccountBalance = paths['/accounts/{account}/balance']['get']['responses']['200']['content']['application/json']
 export type AccountLedger = paths['/accounts/{account}/ledger']['get']['responses']['200']['content']['application/json']

--- a/src/pages/accounting/accounts/AccountDetailPage.vue
+++ b/src/pages/accounting/accounts/AccountDetailPage.vue
@@ -116,6 +116,18 @@ function viewJournalEntry(journalEntryId: number) {
               <span v-if="account.is_system" class="px-2.5 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400">
                 System Account
               </span>
+              <span
+                v-if="account.allow_reconciliation"
+                class="px-2.5 py-0.5 rounded text-xs font-medium bg-teal-100 text-teal-700 dark:bg-teal-900/30 dark:text-teal-400"
+              >
+                Reconcilable
+              </span>
+              <span
+                v-if="account.currency"
+                class="px-2.5 py-0.5 rounded text-xs font-medium bg-slate-100 text-slate-700 dark:bg-slate-700 dark:text-slate-300 font-mono"
+              >
+                {{ account.currency }}
+              </span>
             </div>
             <p v-if="account.description" class="mt-2 text-slate-600 dark:text-slate-400">
               {{ account.description }}
@@ -186,6 +198,18 @@ function viewJournalEntry(journalEntryId: number) {
               <dt class="text-slate-500 dark:text-slate-400">Opening Balance</dt>
               <dd class="font-medium text-slate-900 dark:text-slate-100">
                 {{ formatCurrency(account.opening_balance) }}
+              </dd>
+            </div>
+            <div class="flex justify-between">
+              <dt class="text-slate-500 dark:text-slate-400">Allow Reconciliation</dt>
+              <dd class="font-medium text-slate-900 dark:text-slate-100">
+                {{ account.allow_reconciliation ? 'Yes' : 'No' }}
+              </dd>
+            </div>
+            <div class="flex justify-between">
+              <dt class="text-slate-500 dark:text-slate-400">Account Currency</dt>
+              <dd class="font-medium text-slate-900 dark:text-slate-100 font-mono">
+                {{ account.currency || 'Company Default' }}
               </dd>
             </div>
             <div v-if="account.parent" class="flex justify-between">

--- a/src/pages/accounting/accounts/AccountFormPage.vue
+++ b/src/pages/accounting/accounts/AccountFormPage.vue
@@ -64,6 +64,16 @@ const typeOptions = [
   { value: 'expense', label: 'Beban (Expense)' },
 ]
 
+const currencyOptions = [
+  { value: '', label: 'Company Default' },
+  { value: 'IDR', label: 'IDR' },
+  { value: 'USD', label: 'USD' },
+  { value: 'EUR', label: 'EUR' },
+  { value: 'SGD', label: 'SGD' },
+  { value: 'JPY', label: 'JPY' },
+  { value: 'CNY', label: 'CNY' },
+]
+
 // Subtype options by type
 const subtypeOptions: Record<string, { value: string; label: string }[]> = {
   asset: [
@@ -110,6 +120,8 @@ const accountSchema = z.object({
     return val
   }),
   is_active: z.boolean().default(true),
+  allow_reconciliation: z.boolean().default(false),
+  currency: z.string().optional().nullable(),
   opening_balance: z.union([z.number(), z.string()]).default(0).transform(val => {
     if (typeof val === 'string') return parseFloat(val) || 0
     return val
@@ -129,6 +141,8 @@ const { values: form, errors, handleSubmit, setValues, setFieldValue, defineFiel
     description: '',
     parent_id: null,
     is_active: true,
+    allow_reconciliation: false,
+    currency: '',
     opening_balance: 0,
   },
 })
@@ -140,6 +154,8 @@ const [subtype] = defineField('subtype')
 const [description] = defineField('description')
 const [parentId] = defineField('parent_id')
 const [isActive] = defineField('is_active')
+const [allowReconciliation] = defineField('allow_reconciliation')
+const [currency] = defineField('currency')
 const [openingBalance] = defineField('opening_balance')
 
 // Watch for existing account data
@@ -153,6 +169,8 @@ watch(existingAccount, (account) => {
       description: account.description || '',
       parent_id: account.parent_id ? String(account.parent_id) : '',
       is_active: !!account.is_active,
+      allow_reconciliation: !!account.allow_reconciliation,
+      currency: account.currency || '',
       opening_balance: toNumber(account.opening_balance),
     })
   }
@@ -187,6 +205,8 @@ const onSubmit = handleSubmit(async (formValues) => {
       description: formValues.description || null,
       parent_id: formValues.parent_id ? parseInt(formValues.parent_id, 10) : null,
       is_active: formValues.is_active,
+      allow_reconciliation: formValues.allow_reconciliation,
+      currency: formValues.currency || null,
       opening_balance: formValues.opening_balance,
     }
 
@@ -336,6 +356,23 @@ const onSubmit = handleSubmit(async (formValues) => {
                   placeholder="Optional description for this account"
                 />
               </div>
+
+              <!-- Account Currency -->
+              <div>
+                <label class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
+                  Mata Uang Akun / Account Currency
+                </label>
+                <Select
+                  :model-value="currency || ''"
+                  test-id="account-currency"
+                  :options="currencyOptions"
+                  placeholder="Company Default"
+                  @update:model-value="(v) => setFieldValue('currency', v ? String(v) : '')"
+                />
+                <p class="mt-1 text-sm text-slate-500 dark:text-slate-400">
+                  Leave empty to use the company default currency
+                </p>
+              </div>
             </div>
           </Card>
 
@@ -369,19 +406,36 @@ const onSubmit = handleSubmit(async (formValues) => {
               <h2 class="font-semibold text-slate-900 dark:text-slate-100">Status</h2>
             </template>
 
-            <label class="flex items-center gap-3 cursor-pointer">
-              <input
-                v-model="isActive"
-                type="checkbox"
-                class="w-5 h-5 rounded border-slate-300 dark:border-slate-600 text-orange-500 focus:ring-orange-500"
-              />
-              <div>
-                <span class="font-medium text-slate-900 dark:text-slate-100">Active</span>
-                <p class="text-sm text-slate-500 dark:text-slate-400">
-                  Inactive accounts cannot be used in transactions
-                </p>
-              </div>
-            </label>
+            <div class="space-y-4">
+              <label class="flex items-center gap-3 cursor-pointer">
+                <input
+                  v-model="isActive"
+                  type="checkbox"
+                  class="w-5 h-5 rounded border-slate-300 dark:border-slate-600 text-orange-500 focus:ring-orange-500"
+                />
+                <div>
+                  <span class="font-medium text-slate-900 dark:text-slate-100">Active</span>
+                  <p class="text-sm text-slate-500 dark:text-slate-400">
+                    Inactive accounts cannot be used in transactions
+                  </p>
+                </div>
+              </label>
+
+              <label class="flex items-center gap-3 cursor-pointer">
+                <input
+                  v-model="allowReconciliation"
+                  type="checkbox"
+                  data-testid="account-allow-reconciliation"
+                  class="w-5 h-5 rounded border-slate-300 dark:border-slate-600 text-orange-500 focus:ring-orange-500"
+                />
+                <div>
+                  <span class="font-medium text-slate-900 dark:text-slate-100">Allow Reconciliation</span>
+                  <p class="text-sm text-slate-500 dark:text-slate-400">
+                    Izinkan rekonsiliasi — akun dapat dipilih di rekonsiliasi bank/partner
+                  </p>
+                </div>
+              </label>
+            </div>
           </Card>
 
           <!-- Account Code Guide -->

--- a/src/pages/accounting/accounts/AccountListPage.vue
+++ b/src/pages/accounting/accounts/AccountListPage.vue
@@ -234,8 +234,10 @@ function goToAccount(account: Account) {
       <!-- Header -->
       <div class="px-4 py-3 border-b border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-800/50">
         <div class="grid grid-cols-12 gap-4 text-sm font-medium text-slate-500 dark:text-slate-400">
-          <div class="col-span-5">Account</div>
-          <div class="col-span-2">Type</div>
+          <div class="col-span-4">Account</div>
+          <div class="col-span-1">Type</div>
+          <div class="col-span-1 text-center">Currency</div>
+          <div class="col-span-1 text-center">Reconcile</div>
           <div class="col-span-2 text-right">Balance</div>
           <div class="col-span-1 text-center">Status</div>
           <div class="col-span-2 text-right">Actions</div>

--- a/src/pages/accounting/accounts/AccountListPage.vue
+++ b/src/pages/accounting/accounts/AccountListPage.vue
@@ -4,13 +4,15 @@ import { useRouter } from 'vue-router'
 import {
   useAccountsTree,
   useDeleteAccount,
+  useImportAccounts,
   buildAccountTree,
   type Account,
+  type AccountImportResult,
 } from '@/api/useAccounts'
 import { Button, Input, Select, Card, Modal, useToast } from '@/components/ui'
 import { posChrome } from '@/config/nav'
 import { useFeaturesStore } from '@/stores/features'
-import { Plus, Search } from 'lucide-vue-next'
+import { Plus, Search, Upload } from 'lucide-vue-next'
 import AccountTreeNode from './AccountTreeNode.vue'
 
 const router = useRouter()
@@ -136,6 +138,52 @@ async function handleDelete() {
 function goToAccount(account: Account) {
   router.push(`/accounting/accounts/${account.id}`)
 }
+
+// Import CoA
+const importMutation = useImportAccounts()
+const showImportModal = ref(false)
+const importFile = ref<File | null>(null)
+const importResult = ref<AccountImportResult | null>(null)
+const importError = ref<string | null>(null)
+const fileInputRef = ref<HTMLInputElement | null>(null)
+
+function openImportModal() {
+  importFile.value = null
+  importResult.value = null
+  importError.value = null
+  showImportModal.value = true
+}
+
+function onImportFileChange(event: Event) {
+  const input = event.target as HTMLInputElement
+  importFile.value = input.files?.[0] ?? null
+  importResult.value = null
+  importError.value = null
+}
+
+async function handleImport() {
+  if (!importFile.value) return
+  importError.value = null
+  try {
+    const response = await importMutation.mutateAsync(importFile.value)
+    importResult.value = response.data
+    toast.success(
+      response.message ||
+        `Imported ${response.data.created_count} account(s)`
+    )
+    refetch()
+  } catch (err: unknown) {
+    const axiosErr = err as {
+      response?: { data?: { message?: string; data?: AccountImportResult } }
+    }
+    const data = axiosErr.response?.data
+    if (data?.data) {
+      importResult.value = data.data
+    }
+    importError.value = data?.message || 'Import failed'
+    toast.error(importError.value)
+  }
+}
 </script>
 
 <template>
@@ -146,12 +194,18 @@ function goToAccount(account: Account) {
         <h1 class="text-2xl font-semibold text-slate-900 dark:text-slate-100">{{ posChrome('Chart of Accounts', posPack) }}</h1>
         <p class="text-slate-500 dark:text-slate-400">{{ posPack ? 'Struktur akun perusahaan' : 'Manage your account structure' }}</p>
       </div>
-      <RouterLink to="/accounting/accounts/new">
-        <Button>
-          <Plus class="w-4 h-4 mr-2" />
-          {{ posChrome('New Account', posPack) }}
+      <div class="flex items-center gap-2">
+        <Button variant="secondary" @click="openImportModal">
+          <Upload class="w-4 h-4 mr-2" />
+          {{ posChrome('Import', posPack) }}
         </Button>
-      </RouterLink>
+        <RouterLink to="/accounting/accounts/new">
+          <Button>
+            <Plus class="w-4 h-4 mr-2" />
+            {{ posChrome('New Account', posPack) }}
+          </Button>
+        </RouterLink>
+      </div>
     </div>
 
     <!-- Filters -->
@@ -277,6 +331,73 @@ function goToAccount(account: Account) {
           @click="handleDelete"
         >
           Delete
+        </Button>
+      </template>
+    </Modal>
+
+    <!-- Import CoA Modal -->
+    <Modal
+      :open="showImportModal"
+      title="Import Chart of Accounts"
+      description="Upload a CSV or XLSX file to create accounts in bulk."
+      size="lg"
+      @update:open="showImportModal = $event"
+    >
+      <div class="space-y-4">
+        <div class="rounded-lg border border-dashed border-slate-300 dark:border-slate-600 p-4">
+          <p class="text-sm text-slate-600 dark:text-slate-400 mb-3">
+            Columns: <code class="text-xs">code, name, type, subtype, parent, active, allow_reconciliation, currency</code>
+          </p>
+          <p class="text-xs text-slate-500 dark:text-slate-500 mb-3">
+            <code>parent</code> accepts an existing account code or id. Type must match the parent type.
+          </p>
+          <input
+            ref="fileInputRef"
+            type="file"
+            accept=".csv,.xlsx,.xls,text/csv,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+            class="block w-full text-sm text-slate-600 dark:text-slate-300 file:mr-3 file:py-2 file:px-3 file:rounded-md file:border-0 file:bg-slate-100 file:text-slate-700 dark:file:bg-slate-800 dark:file:text-slate-200"
+            @change="onImportFileChange"
+          />
+          <p v-if="importFile" class="mt-2 text-sm text-slate-700 dark:text-slate-300">
+            Selected: {{ importFile.name }}
+          </p>
+        </div>
+
+        <p v-if="importError" class="text-sm text-red-600 dark:text-red-400">
+          {{ importError }}
+        </p>
+
+        <div
+          v-if="importResult"
+          class="rounded-lg border border-slate-200 dark:border-slate-700 p-3 space-y-2"
+        >
+          <p class="text-sm text-slate-700 dark:text-slate-300">
+            Created: <strong>{{ importResult.created_count }}</strong>
+            · Errors: <strong>{{ importResult.error_count }}</strong>
+          </p>
+          <ul
+            v-if="importResult.errors?.length"
+            class="max-h-48 overflow-y-auto text-sm space-y-1"
+          >
+            <li
+              v-for="(err, idx) in importResult.errors"
+              :key="idx"
+              class="text-amber-700 dark:text-amber-400"
+            >
+              Row {{ err.row }}: {{ err.messages.join('; ') }}
+            </li>
+          </ul>
+        </div>
+      </div>
+      <template #footer>
+        <Button variant="ghost" @click="showImportModal = false">Close</Button>
+        <Button
+          :disabled="!importFile"
+          :loading="importMutation.isPending.value"
+          @click="handleImport"
+        >
+          <Upload class="w-4 h-4 mr-2" />
+          Import
         </Button>
       </template>
     </Modal>

--- a/src/pages/accounting/accounts/AccountTreeNode.vue
+++ b/src/pages/accounting/accounts/AccountTreeNode.vue
@@ -34,7 +34,7 @@ const isSystem = computed(() => !!props.account.is_system)
       @click="$emit('click', account)"
     >
       <!-- Account Name with Tree Indent -->
-      <div class="col-span-5 flex items-center gap-2" :style="{ paddingLeft: level * 24 + 'px' }">
+      <div class="col-span-4 flex items-center gap-2" :style="{ paddingLeft: level * 24 + 'px' }">
         <button
           v-if="hasChildren"
           class="p-0.5 rounded hover:bg-slate-200 dark:hover:bg-slate-700 transition-colors"
@@ -54,12 +54,29 @@ const isSystem = computed(() => !!props.account.is_system)
       </div>
 
       <!-- Type -->
-      <div class="col-span-2">
+      <div class="col-span-1">
         <span
           class="inline-flex px-2 py-0.5 rounded text-xs font-medium"
           :class="getAccountTypeColor(account.type)"
         >
           {{ getAccountTypeLabel(account.type) }}
+        </span>
+      </div>
+
+      <!-- Currency -->
+      <div class="col-span-1 text-center font-mono text-xs text-slate-600 dark:text-slate-400">
+        {{ account.currency || '—' }}
+      </div>
+
+      <!-- Allow Reconciliation -->
+      <div class="col-span-1 text-center">
+        <span
+          class="inline-flex px-2 py-0.5 rounded text-xs font-medium"
+          :class="account.allow_reconciliation
+            ? 'bg-teal-100 text-teal-700 dark:bg-teal-900/30 dark:text-teal-400'
+            : 'bg-slate-100 text-slate-500 dark:bg-slate-700 dark:text-slate-400'"
+        >
+          {{ account.allow_reconciliation ? 'Yes' : 'No' }}
         </span>
       </div>
 


### PR DESCRIPTION
## Summary
- Adds **Import** on Bagan Akun (`AccountListPage`) with CSV/XLSX file modal.
- Calls `POST /accounts/import` via `useImportAccounts`; shows created/error counts and per-row messages.
- Expected columns: `code, name, type, subtype, parent, active, allow_reconciliation, currency`.

Related to satriyop/enter365#25

## Stack note
Branched from `feat/coa-allow-reconciliation-currency` (PR #31 / enter365#24) so the list already shows reconcile/currency. Prefer merging #31 before this, or rebase onto `main` after #24 UI lands.

Companion API PR: https://github.com/satriyop/enter365/pull/31

## Test plan
- [ ] Open Bagan Akun → Import → upload sample CSV → success toast + tree refresh
- [ ] Upload file with invalid rows → modal lists row errors
- [ ] Backend import endpoint available (enter365 feat/coa-import)