### PR TITLE
feat(journals): journals master UI + JE journal selector (#26)

### DIFF
--- a/src/api/useJournalEntries.ts
+++ b/src/api/useJournalEntries.ts
@@ -7,7 +7,10 @@ import type { components, paths } from './types'
 // Types
 // ============================================
 
-export type JournalEntry = components['schemas']['JournalEntryResource']
+export type JournalEntry = components['schemas']['JournalEntryResource'] & {
+  journal_id?: number | null
+  journal?: { id: number; name: string; type: string; sequence_prefix: string } | null
+}
 export type JournalEntryLine = components['schemas']['JournalEntryLineResource']
 
 export interface JournalEntryFilters {
@@ -18,9 +21,13 @@ export interface JournalEntryFilters {
   end_date?: string
   is_posted?: boolean
   fiscal_period_id?: number
+  journal_id?: number
+  journal_type?: 'sales' | 'purchase' | 'bank' | 'cash' | 'miscellaneous'
 }
 
-export type CreateJournalEntryData = paths['/journal-entries']['post']['requestBody']['content']['application/json']
+export type CreateJournalEntryData = paths['/journal-entries']['post']['requestBody']['content']['application/json'] & {
+  journal_id: number
+}
 export type CreateJournalEntryLineData = CreateJournalEntryData['lines'][number]
 
 // ============================================

--- a/src/api/useJournals.ts
+++ b/src/api/useJournals.ts
@@ -1,0 +1,64 @@
+import { createCrudHooks } from './factory'
+
+export type JournalType = 'sales' | 'purchase' | 'bank' | 'cash' | 'miscellaneous'
+
+export interface Journal {
+  id: number
+  name: string
+  type: JournalType
+  sequence_prefix: string
+  default_account_id: number | null
+  currency: string | null
+  is_active: boolean
+  default_account?: {
+    id: number
+    code: string
+    name: string
+  } | null
+  created_at?: string | null
+  updated_at?: string | null
+}
+
+export interface JournalFilters {
+  page?: number
+  per_page?: number
+  search?: string
+  type?: JournalType | ''
+  is_active?: boolean
+}
+
+export interface CreateJournalData {
+  name: string
+  type: JournalType
+  sequence_prefix: string
+  default_account_id?: number | null
+  currency?: string | null
+  is_active?: boolean
+}
+
+export type UpdateJournalData = Partial<CreateJournalData>
+
+const hooks = createCrudHooks<Journal, JournalFilters, CreateJournalData, UpdateJournalData>({
+  resourceName: 'journals',
+  singularName: 'journal',
+  lookupParams: { is_active: true, per_page: 200 },
+})
+
+export const useJournals = hooks.useList
+export const useJournal = hooks.useSingle
+export const useCreateJournal = hooks.useCreate
+export const useUpdateJournal = hooks.useUpdate
+export const useDeleteJournal = hooks.useDelete
+export const useJournalsLookup = hooks.useLookup
+
+export const JOURNAL_TYPE_OPTIONS = [
+  { value: 'sales', label: 'Sales' },
+  { value: 'purchase', label: 'Purchase' },
+  { value: 'bank', label: 'Bank' },
+  { value: 'cash', label: 'Cash' },
+  { value: 'miscellaneous', label: 'Miscellaneous' },
+] as const
+
+export function journalTypeLabel(type: string): string {
+  return JOURNAL_TYPE_OPTIONS.find((o) => o.value === type)?.label ?? type
+}

--- a/src/config/nav.ts
+++ b/src/config/nav.ts
@@ -73,6 +73,7 @@ export const navigation: NavGroup[] = [
     label: 'Accounting',
     items: [
       { name: 'Chart of Accounts', path: '/accounting/accounts', icon: '📒', permission: 'accounts.view' },
+      { name: 'Journals', path: '/accounting/journals', icon: '🗂️', permission: 'journals.view' },
       { name: 'Journal Entries', path: '/accounting/journal-entries', icon: '📝', permission: 'journals.view' },
       { name: 'Fiscal Periods', path: '/accounting/fiscal-periods', icon: '📅', permission: 'fiscal_periods.view' },
       { name: 'Budgets', path: '/accounting/budgets', icon: '📊', permission: 'budgets.view', feature: 'budgeting' },
@@ -146,6 +147,7 @@ export const POS_NAV_ID: Record<string, string> = {
   'Stock Transfer': 'Pindah Stok',
   Products: 'Produk',
   'Chart of Accounts': 'Bagan Akun',
+  'Journals': 'Jurnal (Konfigurasi)',
   'Journal Entries': 'Jurnal',
   'Fiscal Periods': 'Periode Fiskal',
   Payments: 'Pembayaran',

--- a/src/pages/accounting/journal-entries/JournalEntryDetailPage.vue
+++ b/src/pages/accounting/journal-entries/JournalEntryDetailPage.vue
@@ -139,6 +139,7 @@ function viewAccount(accountId: string) {
             </div>
             <p class="text-slate-600 dark:text-slate-400">{{ entry.description }}</p>
             <div class="flex items-center gap-4 mt-2 text-sm text-slate-500 dark:text-slate-400">
+              <span v-if="entry.journal" data-testid="je-journal-name">Journal: {{ entry.journal.name }}</span>
               <span>{{ formatDate(entry.entry_date) }}</span>
               <span v-if="entry.reference">Ref: {{ entry.reference }}</span>
             </div>

--- a/src/pages/accounting/journal-entries/JournalEntryFormPage.vue
+++ b/src/pages/accounting/journal-entries/JournalEntryFormPage.vue
@@ -10,6 +10,7 @@ import {
   type CreateJournalEntryLineData,
 } from '@/api/useJournalEntries'
 import { useAccountsLookup } from '@/api/useAccounts'
+import { useJournalsLookup, journalTypeLabel } from '@/api/useJournals'
 import { formatCurrency } from '@/utils/format'
 import { Button, Card, Input, Select, useToast, CurrencyInput } from '@/components/ui'
 import { ArrowLeft, Save, Loader2, Plus, Trash2, AlertTriangle, CheckCircle } from 'lucide-vue-next'
@@ -19,6 +20,17 @@ const toast = useToast()
 
 // Fetch accounts for dropdown
 const { data: accounts, isLoading: accountsLoading } = useAccountsLookup()
+const { data: journals, isLoading: journalsLoading } = useJournalsLookup()
+const journalId = ref<string>('')
+
+
+const journalOptions = computed(() => {
+  if (!journals.value) return []
+  return journals.value.map((j) => ({
+    value: String(j.id),
+    label: `${j.name} (${journalTypeLabel(j.type)})`,
+  }))
+})
 
 // Account options for select
 const accountOptions = computed(() => {
@@ -115,6 +127,11 @@ const isSubmitting = computed(() => createMutation.isPending.value)
 // Submit form
 async function handleSubmit() {
   // Validate
+  if (!journalId.value) {
+    toast.error('Journal is required')
+    return
+  }
+
   if (!entryDate.value) {
     toast.error('Entry date is required')
     return
@@ -141,6 +158,7 @@ async function handleSubmit() {
   }
 
   const data: CreateJournalEntryData = {
+    journal_id: parseInt(journalId.value, 10),
     entry_date: entryDate.value,
     description: description.value,
     reference: reference.value || undefined,
@@ -184,6 +202,20 @@ async function handleSubmit() {
         </template>
 
         <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
+          <div>
+            <label class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
+              Journal <span class="text-red-500">*</span>
+            </label>
+            <Select
+              :model-value="journalId"
+              :options="journalOptions"
+              :loading="journalsLoading"
+              placeholder="Select journal"
+              :test-id="'je-journal'"
+              @update:model-value="(v) => journalId = v ? String(v) : ''"
+            />
+          </div>
+
           <div>
             <label class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
               Entry Date <span class="text-red-500">*</span>

--- a/src/pages/accounting/journal-entries/JournalEntryListPage.vue
+++ b/src/pages/accounting/journal-entries/JournalEntryListPage.vue
@@ -8,6 +8,7 @@ import {
   type JournalEntry,
   type JournalEntryFilters,
 } from '@/api/useJournalEntries'
+import { JOURNAL_TYPE_OPTIONS, journalTypeLabel } from '@/api/useJournals'
 import { useResourceList } from '@/composables/useResourceList'
 import { formatCurrency, formatDate } from '@/utils/format'
 import { journalUraian } from '@/pages/dashboard/shopHome'
@@ -42,10 +43,20 @@ const {
     is_posted: undefined,
     start_date: undefined,
     end_date: undefined,
+    journal_type: undefined,
   },
 })
 
 // Status options
+const journalTypeOptions = computed(() => [
+  { value: '', label: posChrome('All Journals', posPack.value) },
+  ...JOURNAL_TYPE_OPTIONS.map((o) => ({ value: o.value, label: posChrome(o.label, posPack.value) })),
+])
+
+function handleJournalTypeChange(value: string | number | null) {
+  updateFilter('journal_type', value ? (String(value) as JournalEntryFilters['journal_type']) : undefined)
+}
+
 const statusOptions = computed(() => [
   { value: '', label: posChrome('All Status', posPack.value) },
   { value: 'true', label: posChrome('Posted', posPack.value) },
@@ -64,6 +75,7 @@ function handleStatusChange(value: string | number | null) {
 
 const columns = computed<ResponsiveColumn[]>(() => [
   { key: 'entry_number', label: posChrome('Entry #', posPack.value), mobilePriority: 1 },
+  { key: 'journal', label: posChrome('Journal', posPack.value), showInMobile: false },
   { key: 'entry_date', label: posChrome('Date', posPack.value), mobilePriority: 2 },
   { key: 'description', label: posChrome('Description', posPack.value), mobilePriority: 3 },
   { key: 'total_debit', label: posChrome('Debit', posPack.value), align: 'right', showInMobile: false },
@@ -140,6 +152,17 @@ function viewEntry(entry: JournalEntry) {
           />
         </div>
 
+        <!-- Journal Type Filter -->
+        <div class="min-w-[11rem]">
+          <Select
+            :model-value="filters.journal_type ?? ''"
+            :options="journalTypeOptions"
+            :placeholder="posChrome('All Journals', posPack)"
+            :test-id="'je-journal-type-filter'"
+            @update:model-value="handleJournalTypeChange"
+          />
+        </div>
+
         <!-- Status Filter -->
         <div class="min-w-[11rem]">
           <Select
@@ -197,6 +220,14 @@ function viewEntry(entry: JournalEntry) {
         <template #cell-entry_number="{ item }">
           <span class="font-mono text-orange-600 dark:text-orange-400 font-medium">
             {{ item.entry_number }}
+          </span>
+        </template>
+
+
+        <!-- Journal -->
+        <template #cell-journal="{ item }">
+          <span class="text-slate-700 dark:text-slate-300">
+            {{ item.journal?.name ?? '—' }}
           </span>
         </template>
 

--- a/src/pages/accounting/journals/JournalFormPage.vue
+++ b/src/pages/accounting/journals/JournalFormPage.vue
@@ -1,0 +1,229 @@
+<script setup lang="ts">
+import { computed, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { useForm } from 'vee-validate'
+import { toTypedSchema } from '@vee-validate/zod'
+import { z } from 'zod'
+import {
+  useJournal,
+  useCreateJournal,
+  useUpdateJournal,
+  JOURNAL_TYPE_OPTIONS,
+  type CreateJournalData,
+  type JournalType,
+} from '@/api/useJournals'
+import { useAccountsLookup } from '@/api/useAccounts'
+import { setServerErrors } from '@/composables/useValidatedForm'
+import { Button, Card, Input, Select, useToast } from '@/components/ui'
+import { ArrowLeft, Save, Loader2 } from 'lucide-vue-next'
+
+const route = useRoute()
+const router = useRouter()
+const toast = useToast()
+
+const journalId = computed(() => (route.params.id ? String(route.params.id) : null))
+const isEditing = computed(() => !!journalId.value)
+const pageTitle = computed(() => (isEditing.value ? 'Edit Journal' : 'New Journal'))
+
+const { data: existingJournal, isLoading: loadingJournal } = useJournal(
+  computed(() => journalId.value ?? ''),
+)
+
+const { data: accounts, isLoading: accountsLoading } = useAccountsLookup()
+
+const accountOptions = computed(() => {
+  const options = [{ value: '', label: 'None' }]
+  const list = Array.isArray(accounts.value)
+    ? accounts.value
+    : ((accounts.value as { data?: { id: number; code: string; name: string }[] } | undefined)?.data ?? [])
+  list.forEach((acc) => {
+    options.push({ value: String(acc.id), label: `${acc.code} - ${acc.name}` })
+  })
+  return options
+})
+
+const typeOptions = JOURNAL_TYPE_OPTIONS.map((o) => ({ value: o.value, label: o.label }))
+
+const currencyOptions = [
+  { value: '', label: 'Company Default' },
+  { value: 'IDR', label: 'IDR' },
+  { value: 'USD', label: 'USD' },
+  { value: 'EUR', label: 'EUR' },
+  { value: 'SGD', label: 'SGD' },
+  { value: 'JPY', label: 'JPY' },
+  { value: 'CNY', label: 'CNY' },
+]
+
+const schema = z.object({
+  name: z.string().min(1, 'Name is required').max(255),
+  type: z.enum(['sales', 'purchase', 'bank', 'cash', 'miscellaneous']),
+  sequence_prefix: z.string().min(1, 'Sequence prefix is required').max(32),
+  default_account_id: z.string().optional(),
+  currency: z.string().optional(),
+  is_active: z.boolean(),
+})
+
+type FormValues = z.infer<typeof schema>
+
+const { errors, handleSubmit, setValues, setErrors, defineField } = useForm<FormValues>({
+  validationSchema: toTypedSchema(schema),
+  initialValues: {
+    name: '',
+    type: 'miscellaneous',
+    sequence_prefix: '',
+    default_account_id: '',
+    currency: '',
+    is_active: true,
+  },
+})
+
+const [name] = defineField('name')
+const [type] = defineField('type')
+const [sequencePrefix] = defineField('sequence_prefix')
+const [defaultAccountId] = defineField('default_account_id')
+const [currency] = defineField('currency')
+const [isActive] = defineField('is_active')
+
+watch(existingJournal, (journal) => {
+  if (!journal) return
+  setValues({
+    name: journal.name,
+    type: journal.type,
+    sequence_prefix: journal.sequence_prefix,
+    default_account_id: journal.default_account_id ? String(journal.default_account_id) : '',
+    currency: journal.currency ?? '',
+    is_active: journal.is_active,
+  })
+}, { immediate: true })
+
+const createMutation = useCreateJournal()
+const updateMutation = useUpdateJournal()
+const isSubmitting = computed(() => createMutation.isPending.value || updateMutation.isPending.value)
+
+const onSubmit = handleSubmit(async (values) => {
+  const payload: CreateJournalData = {
+    name: values.name,
+    type: values.type as JournalType,
+    sequence_prefix: values.sequence_prefix,
+    default_account_id: values.default_account_id ? Number(values.default_account_id) : null,
+    currency: values.currency || null,
+    is_active: values.is_active,
+  }
+
+  try {
+    if (isEditing.value && journalId.value) {
+      await updateMutation.mutateAsync({ id: journalId.value, data: payload })
+      toast.success('Journal updated')
+    } else {
+      await createMutation.mutateAsync(payload)
+      toast.success('Journal created')
+    }
+    router.push('/accounting/journals')
+  } catch (err: unknown) {
+    const axiosErr = err as { response?: { data?: { errors?: Record<string, string[]> } } }
+    if (axiosErr.response?.data?.errors) {
+      setServerErrors({ setErrors }, axiosErr.response.data.errors)
+    }
+    toast.error(isEditing.value ? 'Failed to update journal' : 'Failed to create journal')
+  }
+})
+</script>
+
+<template>
+  <div>
+    <div class="flex items-center gap-2 text-sm text-slate-500 dark:text-slate-400 mb-4">
+      <RouterLink to="/accounting/journals" class="hover:text-slate-700 dark:hover:text-slate-300 flex items-center gap-1">
+        <ArrowLeft class="w-4 h-4" />
+        Journals
+      </RouterLink>
+      <span>/</span>
+      <span class="text-slate-900 dark:text-slate-100">{{ pageTitle }}</span>
+    </div>
+
+    <div class="mb-6">
+      <h1 class="text-2xl font-semibold text-slate-900 dark:text-slate-100">{{ pageTitle }}</h1>
+      <p class="text-slate-500 dark:text-slate-400">Set journal type, sequence prefix, and optional default account</p>
+    </div>
+
+    <div v-if="isEditing && loadingJournal" class="py-12 text-center text-slate-500">
+      <Loader2 class="w-5 h-5 animate-spin inline mr-2" />
+      Loading...
+    </div>
+
+    <form v-else novalidate @submit.prevent="onSubmit">
+      <Card class="mb-6 max-w-2xl">
+        <div class="space-y-4">
+          <div>
+            <label class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
+              Name <span class="text-red-500">*</span>
+            </label>
+            <Input v-model="name" data-testid="journal-name" placeholder="e.g. Bank BCA" />
+            <p v-if="errors.name" class="text-sm text-red-500 mt-1">{{ errors.name }}</p>
+          </div>
+
+          <div>
+            <label class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
+              Type <span class="text-red-500">*</span>
+            </label>
+            <Select
+              :model-value="type"
+              :options="typeOptions"
+              :test-id="'journal-type'"
+              @update:model-value="(v) => type = String(v) as JournalType"
+            />
+            <p v-if="errors.type" class="text-sm text-red-500 mt-1">{{ errors.type }}</p>
+          </div>
+
+          <div>
+            <label class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
+              Sequence Prefix <span class="text-red-500">*</span>
+            </label>
+            <Input v-model="sequencePrefix" data-testid="journal-prefix" placeholder="e.g. BCA-" />
+            <p class="text-xs text-slate-500 mt-1">Used when numbering journal entries (e.g. BCA-202609-0001)</p>
+            <p v-if="errors.sequence_prefix" class="text-sm text-red-500 mt-1">{{ errors.sequence_prefix }}</p>
+          </div>
+
+          <div>
+            <label class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
+              Default Account
+            </label>
+            <Select
+              :model-value="defaultAccountId ?? ''"
+              :options="accountOptions"
+              :loading="accountsLoading"
+              :test-id="'journal-default-account'"
+              @update:model-value="(v) => defaultAccountId = v ? String(v) : ''"
+            />
+          </div>
+
+          <div>
+            <label class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
+              Currency
+            </label>
+            <Select
+              :model-value="currency ?? ''"
+              :options="currencyOptions"
+              :test-id="'journal-currency'"
+              @update:model-value="(v) => currency = v ? String(v) : ''"
+            />
+            <p class="text-xs text-slate-500 mt-1">Natural for bank/cash journals</p>
+          </div>
+
+          <label class="flex items-center gap-2 text-sm text-slate-700 dark:text-slate-300">
+            <input v-model="isActive" type="checkbox" class="rounded border-slate-300" data-testid="journal-active" />
+            Active
+          </label>
+        </div>
+      </Card>
+
+      <div class="flex gap-3">
+        <Button type="button" variant="ghost" @click="router.push('/accounting/journals')">Cancel</Button>
+        <Button type="submit" data-testid="journal-save" :disabled="isSubmitting">
+          <Loader2 v-if="isSubmitting" class="w-4 h-4 mr-1 animate-spin" />
+          <Save v-else class="w-4 h-4 mr-1" />
+          Save
+        </Button>
+      </div>
+    </form>
+  </div>
+</template>

--- a/src/pages/accounting/journals/JournalListPage.vue
+++ b/src/pages/accounting/journals/JournalListPage.vue
@@ -1,0 +1,192 @@
+<script setup lang="ts">
+import { useRouter } from 'vue-router'
+import {
+  useJournals,
+  useDeleteJournal,
+  journalTypeLabel,
+  JOURNAL_TYPE_OPTIONS,
+  type Journal,
+  type JournalFilters,
+} from '@/api/useJournals'
+import { useResourceList } from '@/composables/useResourceList'
+import { Button, Input, Select, Card, Modal, Pagination, useToast, ResponsiveTable, type ResponsiveColumn } from '@/components/ui'
+import { Plus, Search } from 'lucide-vue-next'
+
+const router = useRouter()
+const toast = useToast()
+
+const {
+  items: journals,
+  pagination,
+  isLoading,
+  error,
+  isEmpty,
+  filters,
+  updateFilter,
+  goToPage,
+  deleteConfirmation,
+} = useResourceList<Journal, JournalFilters>({
+  useListHook: useJournals,
+  initialFilters: {
+    page: 1,
+    per_page: 50,
+    search: '',
+    type: undefined,
+  },
+})
+
+const typeOptions = [
+  { value: '', label: 'All Types' },
+  ...JOURNAL_TYPE_OPTIONS.map((o) => ({ value: o.value, label: o.label })),
+]
+
+function handleTypeChange(value: string | number | null) {
+  updateFilter('type', value ? (String(value) as JournalFilters['type']) : undefined)
+}
+
+const columns: ResponsiveColumn[] = [
+  { key: 'name', label: 'Journal Name', mobilePriority: 1 },
+  { key: 'type', label: 'Type', mobilePriority: 2 },
+  { key: 'sequence_prefix', label: 'Sequence Prefix', mobilePriority: 3 },
+  { key: 'currency', label: 'Currency', showInMobile: false },
+  { key: 'is_active', label: 'Status', mobilePriority: 4 },
+]
+
+const deleteMutation = useDeleteJournal()
+
+async function handleDelete() {
+  const id = deleteConfirmation.executeDelete()
+  if (!id) return
+  try {
+    await deleteMutation.mutateAsync(id as number)
+    toast.success('Journal deleted')
+  } catch {
+    toast.error('Failed to delete journal (it may be in use)')
+  }
+}
+
+function editJournal(journal: Journal) {
+  router.push(`/accounting/journals/${journal.id}/edit`)
+}
+</script>
+
+<template>
+  <div>
+    <div class="flex items-center justify-between mb-6">
+      <div>
+        <h1 class="text-2xl font-semibold text-slate-900 dark:text-slate-100">Journals</h1>
+        <p class="text-slate-500 dark:text-slate-400">
+          Configure sales, purchase, bank, cash, and miscellaneous journals
+        </p>
+      </div>
+      <Button data-testid="journal-create" @click="router.push('/accounting/journals/new')">
+        <Plus class="w-4 h-4 mr-1" />
+        New Journal
+      </Button>
+    </div>
+
+    <Card class="mb-4">
+      <div class="flex flex-col sm:flex-row gap-3 p-4">
+        <div class="relative flex-1">
+          <Search class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400" />
+          <Input
+            :model-value="filters.search ?? ''"
+            class="pl-9"
+            placeholder="Search journals..."
+            data-testid="journal-search"
+            @update:model-value="(v) => updateFilter('search', String(v))"
+          />
+        </div>
+        <Select
+          :model-value="filters.type ?? ''"
+          :options="typeOptions"
+          class="sm:w-48"
+          :test-id="'journal-type-filter'"
+          @update:model-value="handleTypeChange"
+        />
+      </div>
+    </Card>
+
+    <Card>
+      <div v-if="error" class="py-12 text-center text-red-500">Failed to load journals</div>
+      <div v-else-if="isEmpty && !isLoading" class="py-12 text-center text-slate-500">No journals found</div>
+      <ResponsiveTable
+        v-else
+        :items="journals ?? []"
+        :columns="columns"
+        :loading="isLoading"
+        empty-message="No journals found"
+        @row-click="editJournal"
+      >
+        <template #cell-name="{ item }">
+          <span class="font-medium text-slate-900 dark:text-slate-100">{{ item.name }}</span>
+        </template>
+        <template #cell-type="{ item }">
+          <span class="inline-flex px-2 py-0.5 rounded text-xs bg-slate-100 dark:bg-slate-800">
+            {{ journalTypeLabel(item.type) }}
+          </span>
+        </template>
+        <template #cell-sequence_prefix="{ item }">
+          <code class="text-sm">{{ item.sequence_prefix }}</code>
+        </template>
+        <template #cell-currency="{ item }">
+          {{ item.currency || '—' }}
+        </template>
+        <template #cell-is_active="{ item }">
+          <span
+            class="inline-flex px-2 py-0.5 rounded text-xs"
+            :class="item.is_active
+              ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
+              : 'bg-slate-100 text-slate-600 dark:bg-slate-700 dark:text-slate-400'"
+          >
+            {{ item.is_active ? 'Active' : 'Inactive' }}
+          </span>
+        </template>
+        <template #actions="{ item }">
+          <div class="flex items-center justify-end gap-2">
+            <Button variant="ghost" size="xs" @click.stop="editJournal(item)">Edit</Button>
+            <Button
+              variant="ghost"
+              size="xs"
+              class="text-red-500 hover:text-red-600"
+              @click.stop="deleteConfirmation.confirmDelete(item.id)"
+            >
+              Delete
+            </Button>
+          </div>
+        </template>
+      </ResponsiveTable>
+
+      <div v-if="pagination" class="px-6 py-4 border-t border-slate-200 dark:border-slate-700">
+        <Pagination
+          :current-page="pagination.current_page"
+          :total-pages="pagination.last_page"
+          :total="pagination.total"
+          :per-page="pagination.per_page"
+          @page-change="goToPage"
+        />
+      </div>
+    </Card>
+
+    <Modal
+      :open="deleteConfirmation.showModal.value"
+      title="Delete Journal"
+      size="sm"
+      @update:open="deleteConfirmation.showModal.value = $event"
+    >
+      <p class="text-slate-600 dark:text-slate-400">
+        Delete this journal? Journals with existing entries cannot be deleted.
+      </p>
+      <template #footer>
+        <Button variant="ghost" @click="deleteConfirmation.cancelDelete()">Cancel</Button>
+        <Button
+          variant="destructive"
+          :loading="deleteMutation.isPending.value"
+          @click="handleDelete"
+        >
+          Delete
+        </Button>
+      </template>
+    </Modal>
+  </div>
+</template>

--- a/src/router/access.ts
+++ b/src/router/access.ts
@@ -3,6 +3,8 @@ export const PERMISSION_ROUTE_PREFIXES: Array<{ prefix: string; permission: stri
   { prefix: '/inventory/opnames/new', permission: 'stock_opnames.create' },
   { prefix: '/inventory/adjust', permission: 'inventory.adjust' },
   { prefix: '/inventory/transfer', permission: 'inventory.transfer' },
+  { prefix: '/accounting/journals/new', permission: 'journals.create' },
+  { prefix: '/accounting/journals', permission: 'journals.view' },
   { prefix: '/accounting/journal-entries/new', permission: 'journals.create' },
   { prefix: '/accounting/journal-entries', permission: 'journals.view' },
   { prefix: '/reports/stock-summary', permission: 'inventory.view' },

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -515,6 +515,25 @@ const router = createRouter({
           component: () => import('@/pages/accounting/accounts/AccountFormPage.vue'),
           meta: { breadcrumb: 'Edit Account' }
         },
+        // Accounting - Journals master routes
+        {
+          path: 'accounting/journals',
+          name: 'journals',
+          component: () => import('@/pages/accounting/journals/JournalListPage.vue'),
+          meta: { breadcrumb: 'Journals' }
+        },
+        {
+          path: 'accounting/journals/new',
+          name: 'journal-new',
+          component: () => import('@/pages/accounting/journals/JournalFormPage.vue'),
+          meta: { breadcrumb: 'New Journal' }
+        },
+        {
+          path: 'accounting/journals/:id/edit',
+          name: 'journal-edit',
+          component: () => import('@/pages/accounting/journals/JournalFormPage.vue'),
+          meta: { breadcrumb: 'Edit Journal' }
+        },
         // Accounting - Journal Entries routes
         {
           path: 'accounting/journal-entries',


### PR DESCRIPTION
## Summary
- New **Journals** list/form under Accounting (CRUD via `/api/v1/journals`).
- Nav + router + access: `/accounting/journals`.
- Journal Entry create form requires a **Journal** selector; list can filter by journal type; detail shows journal name.
- Pairs with backend PR: https://github.com/satriyop/enter365/pull/33

Related to satriyop/enter365#26.

## Test plan
- [ ] Journals list shows seeded Sales/Purchase/Bank/Cash/Miscellaneous (after API deploy)
- [ ] Create/edit journal (prefix, type, optional default account/currency)
- [ ] New JE requires journal; submit includes `journal_id`
- [ ] JE list filter by journal type
- [ ] JE detail shows journal name

## Notes
- Do not merge until backend #33 is available in the target env.