### PR TITLE
feat(journals): partner on journal entry lines UI (#27)

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -8657,10 +8657,12 @@ export interface components {
             id: number;
             journal_entry_id: number;
             account_id: number;
+            partner_id?: number | null;
             description: string;
             debit: number;
             credit: number;
             account?: components["schemas"]["AccountResource"];
+            partner?: components["schemas"]["ContactResource"] | null;
             created_at: string | null;
             updated_at: string | null;
         };
@@ -10554,6 +10556,7 @@ export interface components {
             reference?: string | null;
             lines: {
                 account_id: number;
+                partner_id?: number | null;
                 description?: string | null;
                 debit?: number;
                 credit?: number;

--- a/src/api/useJournalEntries.ts
+++ b/src/api/useJournalEntries.ts
@@ -23,6 +23,7 @@ export interface JournalEntryFilters {
   fiscal_period_id?: number
   journal_id?: number
   journal_type?: 'sales' | 'purchase' | 'bank' | 'cash' | 'miscellaneous'
+  partner_id?: number
 }
 
 export type CreateJournalEntryData = paths['/journal-entries']['post']['requestBody']['content']['application/json'] & {
@@ -170,6 +171,7 @@ export function validateJournalLines(lines: CreateJournalEntryLineData[]): strin
 export function createEmptyLine(): CreateJournalEntryLineData {
   return {
     account_id: 0,
+    partner_id: null,
     description: '',
     debit: 0,
     credit: 0,

--- a/src/pages/accounting/journal-entries/JournalEntryDetailPage.vue
+++ b/src/pages/accounting/journal-entries/JournalEntryDetailPage.vue
@@ -250,6 +250,7 @@ function viewAccount(accountId: string) {
             <thead class="bg-slate-50 dark:bg-slate-800/50">
               <tr>
                 <th class="px-4 py-3 text-left font-medium text-slate-500 dark:text-slate-400">Account</th>
+                <th class="px-4 py-3 text-left font-medium text-slate-500 dark:text-slate-400">Partner</th>
                 <th class="px-4 py-3 text-left font-medium text-slate-500 dark:text-slate-400">Description</th>
                 <th class="px-4 py-3 text-right font-medium text-slate-500 dark:text-slate-400">Debit</th>
                 <th class="px-4 py-3 text-right font-medium text-slate-500 dark:text-slate-400">Credit</th>
@@ -271,6 +272,13 @@ function viewAccount(accountId: string) {
                     <span class="ml-2 text-slate-900 dark:text-slate-100">{{ line.account.name }}</span>
                   </button>
                 </td>
+                <td class="px-4 py-3 text-slate-600 dark:text-slate-400" data-testid="je-line-partner">
+                  <template v-if="line.partner">
+                    <span class="font-mono text-slate-500 dark:text-slate-400">{{ line.partner.code }}</span>
+                    <span class="ml-2 text-slate-900 dark:text-slate-100">{{ line.partner.name }}</span>
+                  </template>
+                  <template v-else>-</template>
+                </td>
                 <td class="px-4 py-3 text-slate-600 dark:text-slate-400">
                   {{ line.description || '-' }}
                 </td>
@@ -284,7 +292,7 @@ function viewAccount(accountId: string) {
             </tbody>
             <tfoot class="bg-slate-50 dark:bg-slate-800/50 font-medium">
               <tr>
-                <td class="px-4 py-3 text-slate-900 dark:text-slate-100" colspan="2">Total</td>
+                <td class="px-4 py-3 text-slate-900 dark:text-slate-100" colspan="3">Total</td>
                 <td class="px-4 py-3 text-right font-mono text-slate-900 dark:text-slate-100">
                   {{ formatCurrency(entry.total_debit) }}
                 </td>

--- a/src/pages/accounting/journal-entries/JournalEntryFormPage.vue
+++ b/src/pages/accounting/journal-entries/JournalEntryFormPage.vue
@@ -10,6 +10,7 @@ import {
   type CreateJournalEntryLineData,
 } from '@/api/useJournalEntries'
 import { useAccountsLookup } from '@/api/useAccounts'
+import { useContactsLookup } from '@/api/useContacts'
 import { useJournalsLookup, journalTypeLabel } from '@/api/useJournals'
 import { formatCurrency } from '@/utils/format'
 import { Button, Card, Input, Select, useToast, CurrencyInput } from '@/components/ui'
@@ -21,6 +22,7 @@ const toast = useToast()
 // Fetch accounts for dropdown
 const { data: accounts, isLoading: accountsLoading } = useAccountsLookup()
 const { data: journals, isLoading: journalsLoading } = useJournalsLookup()
+const { data: contacts, isLoading: contactsLoading } = useContactsLookup()
 const journalId = ref<string>('')
 
 
@@ -38,6 +40,14 @@ const accountOptions = computed(() => {
   return accounts.value.map(acc => ({
     value: String(acc.id),
     label: `${acc.code} - ${acc.name}`,
+  }))
+})
+
+const partnerOptions = computed(() => {
+  if (!contacts.value) return []
+  return contacts.value.map((c) => ({
+    value: String(c.id),
+    label: `${c.code} - ${c.name}`,
   }))
 })
 
@@ -261,8 +271,11 @@ async function handleSubmit() {
           <table class="w-full text-sm">
             <thead class="bg-slate-50 dark:bg-slate-800/50">
               <tr>
-                <th class="px-4 py-3 text-left font-medium text-slate-500 dark:text-slate-400 w-2/5">
+                <th class="px-4 py-3 text-left font-medium text-slate-500 dark:text-slate-400 w-1/4">
                   Account <span class="text-red-500">*</span>
+                </th>
+                <th class="px-4 py-3 text-left font-medium text-slate-500 dark:text-slate-400 w-1/5">
+                  Partner
                 </th>
                 <th class="px-4 py-3 text-left font-medium text-slate-500 dark:text-slate-400 w-1/5">
                   Description
@@ -287,6 +300,18 @@ async function handleSubmit() {
                     :loading="accountsLoading"
                     placeholder="Select account"
                     @update:model-value="(v) => line.account_id = v ? parseInt(String(v), 10) : 0"
+                  />
+                </td>
+
+                <!-- Partner -->
+                <td class="px-4 py-2">
+                  <Select
+                    :test-id="`je-line-${index}-partner`"
+                    :model-value="line.partner_id ? String(line.partner_id) : ''"
+                    :options="partnerOptions"
+                    :loading="contactsLoading"
+                    placeholder="Optional"
+                    @update:model-value="(v) => line.partner_id = v ? parseInt(String(v), 10) : null"
                   />
                 </td>
 
@@ -338,7 +363,7 @@ async function handleSubmit() {
             </tbody>
             <tfoot class="bg-slate-50 dark:bg-slate-800/50 font-medium">
               <tr>
-                <td class="px-4 py-3 text-slate-900 dark:text-slate-100" colspan="2">Total</td>
+                <td class="px-4 py-3 text-slate-900 dark:text-slate-100" colspan="3">Total</td>
                 <td class="px-4 py-3 text-right font-mono text-slate-900 dark:text-slate-100">
                   {{ formatCurrency(totals.totalDebit) }}
                 </td>
@@ -404,6 +429,7 @@ async function handleSubmit() {
         <h2 class="font-semibold text-slate-900 dark:text-slate-100">Tips</h2>
       </template>
       <ul class="text-sm text-slate-600 dark:text-slate-400 space-y-2">
+        <li>• Partner (customer/vendor) is optional on each line for AR/AP reporting</li>
         <li>• Each line can only have a debit OR credit amount, not both</li>
         <li>• Total debits must equal total credits for a balanced entry</li>
         <li>• Use "Auto-Balance" to automatically fill the last line</li>

--- a/src/pages/accounting/journal-entries/JournalEntryListPage.vue
+++ b/src/pages/accounting/journal-entries/JournalEntryListPage.vue
@@ -9,6 +9,7 @@ import {
   type JournalEntryFilters,
 } from '@/api/useJournalEntries'
 import { JOURNAL_TYPE_OPTIONS, journalTypeLabel } from '@/api/useJournals'
+import { useContactsLookup } from '@/api/useContacts'
 import { useResourceList } from '@/composables/useResourceList'
 import { formatCurrency, formatDate } from '@/utils/format'
 import { journalUraian } from '@/pages/dashboard/shopHome'
@@ -22,6 +23,15 @@ const toast = useToast()
 const features = useFeaturesStore()
 const posPack = computed(() => features.preset === 'pos')
 const title = computed(() => posChrome('Journal Entries', posPack.value, POS_NAV_ID))
+
+const { data: contacts, isLoading: contactsLoading } = useContactsLookup()
+const partnerOptions = computed(() => [
+  { value: '', label: posChrome('All Partners', posPack.value) },
+  ...((contacts.value ?? []).map((c) => ({
+    value: String(c.id),
+    label: `${c.code} - ${c.name}`,
+  }))),
+])
 
 // Resource list with filters and pagination
 const {
@@ -44,6 +54,7 @@ const {
     start_date: undefined,
     end_date: undefined,
     journal_type: undefined,
+    partner_id: undefined,
   },
 })
 
@@ -55,6 +66,10 @@ const journalTypeOptions = computed(() => [
 
 function handleJournalTypeChange(value: string | number | null) {
   updateFilter('journal_type', value ? (String(value) as JournalEntryFilters['journal_type']) : undefined)
+}
+
+function handlePartnerChange(value: string | number | null) {
+  updateFilter('partner_id', value ? Number(value) : undefined)
 }
 
 const statusOptions = computed(() => [
@@ -160,6 +175,18 @@ function viewEntry(entry: JournalEntry) {
             :placeholder="posChrome('All Journals', posPack)"
             :test-id="'je-journal-type-filter'"
             @update:model-value="handleJournalTypeChange"
+          />
+        </div>
+
+        <!-- Partner Filter -->
+        <div class="min-w-[14rem]">
+          <Select
+            :model-value="filters.partner_id ? String(filters.partner_id) : ''"
+            :options="partnerOptions"
+            :loading="contactsLoading"
+            :placeholder="posChrome('All Partners', posPack)"
+            :test-id="'je-partner-filter'"
+            @update:model-value="handlePartnerChange"
           />
         </div>
 


### PR DESCRIPTION
## Summary
- Optional **Partner** (contact) column on Jurnal create line grid and detail lines.
- Jurnal list filter by partner (`partner_id`).
- Types + `createEmptyLine` / filters updated for `partner_id`.

## Stack
- **Base:** `feat/journals-master` (open PR #33 / issue #26 — journals master UI + JE journal selector).
- Do **not** merge until #33 lands (or retarget to `main` after).

Companion API: https://github.com/satriyop/enter365/pull/39

Related to satriyop/enter365#27.

## Test plan
- [ ] Buat jurnal: Partner select on each line (optional); submit persists
- [ ] Detail: Partner shown on lines
- [ ] List: Partner filter narrows entries
- [ ] Type-check / Vitest green in CI

## Notes
- Do not merge.