### PR TITLE
feat(pos): show cash rounding on the till and struk

### DIFF
--- a/src/api/usePos.ts
+++ b/src/api/usePos.ts
@@ -23,6 +23,7 @@ export interface PosSession {
   service_rate?: number
   tax_add_rate?: number
   tax_add_name?: string | null
+  cash_rounding_unit?: number
   opening_cash_amount: number
   expected_cash_amount: number | null
   counted_cash_amount: number | null
@@ -43,6 +44,8 @@ export interface PosSale {
   service_amount?: number
   tax_amount?: number
   payable_amount: number
+  rounding_amount?: number
+  cash_due_amount?: number
   cash_received_amount: number
   change_amount: number
   sold_at: string

--- a/src/pages/pos/KasirPage.vue
+++ b/src/pages/pos/KasirPage.vue
@@ -24,7 +24,7 @@ import { bindOutletId, formatHoldClock, resolveStartWarehouse, tillExpectedCash 
 import { tillTileMarks } from '@/pages/pos/tillMarks'
 import { printTillReceipt } from '@/pages/pos/tillPrint'
 import { onRescue } from '@/utils/clickRescue'
-import { tillBill } from './tillBill'
+import { roundCashPayable, tillBill } from './tillBill'
 import { typeCashReceived } from './tillCash'
 import { shouldShowTillOfflineDialog } from './tillErrors'
 import { useQueryClient } from '@tanstack/vue-query'
@@ -140,9 +140,16 @@ const bill = computed(() => tillBill(
   session.value?.tax_add_rate,
 ))
 const payable = computed(() => bill.value.payable)
+const cashDue = computed(() => {
+  if (way.value !== 'cash') {
+    return payable.value
+  }
+  return roundCashPayable(payable.value, session.value?.cash_rounding_unit ?? 100)
+})
+const roundingAmount = computed(() => cashDue.value - payable.value)
 const itemCount = computed(() => cart.value.reduce((sum, line) => sum + line.quantity, 0))
-const change = computed(() => received.value - payable.value)
-const canCommit = computed(() => way.value === 'qris' || received.value >= payable.value)
+const change = computed(() => received.value - cashDue.value)
+const canCommit = computed(() => way.value === 'qris' || received.value >= cashDue.value)
 const countedCash = computed(() => DENOMS.reduce((sum, d) => sum + d * (count[d] || 0), 0))
 const expectedCash = computed(() => tillExpectedCash(session.value?.opening_cash_amount ?? 0, sales.value))
 
@@ -762,6 +769,14 @@ onMounted(async () => {
               <div class="l">Total tagihan</div>
               <div class="v">{{ rp(payable) }}</div>
             </div>
+            <div v-if="way === 'cash' && roundingAmount !== 0" class="slab" data-testid="kasir-rounding">
+              <div class="l">Pembulatan</div>
+              <div class="v">{{ rp(roundingAmount) }}</div>
+            </div>
+            <div v-if="way === 'cash' && roundingAmount !== 0" class="slab" data-testid="kasir-cash-due">
+              <div class="l">Tunai dibayar</div>
+              <div class="v">{{ rp(cashDue) }}</div>
+            </div>
             <div v-if="way === 'qris'" class="banner warn" style="margin:0">
               <span>!</span>
               <div>
@@ -783,7 +798,7 @@ onMounted(async () => {
           <div class="pr">
             <template v-if="way === 'cash'">
               <div class="quick">
-                <button class="pas" data-testid="kasir-exact-cash" @click="received = payable">Uang pas · {{ rp(payable) }}</button>
+                <button class="pas" data-testid="kasir-exact-cash" @click="received = cashDue">Uang pas · {{ rp(cashDue) }}</button>
                 <button v-for="q in QUICK" :key="q" @click="received = q">{{ rp(q) }}</button>
               </div>
               <div class="keys">

--- a/src/pages/pos/__tests__/tillBill.test.ts
+++ b/src/pages/pos/__tests__/tillBill.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { addOnBill, tillBill } from '../tillBill'
+import { addOnBill, roundCashPayable, tillBill } from '../tillBill'
 
 describe('addOnBill', () => {
   it('charges Hakau cafe 22000 as 25410', () => {
@@ -23,5 +23,23 @@ describe('tillBill', () => {
 
   it('adds service and PBJT in add mode', () => {
     expect(tillBill(22_000, 'add', 5, 10).payable).toBe(25_410)
+  })
+})
+
+describe('roundCashPayable', () => {
+  it('rounds Air Mineral 9240 down to 9200', () => {
+    expect(roundCashPayable(9_240)).toBe(9_200)
+  })
+
+  it('rounds Hakau 25410 down to 25400', () => {
+    expect(roundCashPayable(25_410)).toBe(25_400)
+  })
+
+  it('rounds half of the unit up', () => {
+    expect(roundCashPayable(9_250)).toBe(9_300)
+  })
+
+  it('leaves an already-round bill unchanged', () => {
+    expect(roundCashPayable(9_200)).toBe(9_200)
   })
 })

--- a/src/pages/pos/__tests__/tillPrint.test.ts
+++ b/src/pages/pos/__tests__/tillPrint.test.ts
@@ -13,7 +13,9 @@ describe('tillReceiptHtml', () => {
       service_amount: 400,
       tax_amount: 840,
       payable_amount: 9_240,
-      cash_received_amount: 9_240,
+      rounding_amount: -40,
+      cash_due_amount: 9_200,
+      cash_received_amount: 9_200,
       change_amount: 0,
       sold_at: '2026-08-31T13:00:00+07:00',
       void_reason: null,
@@ -29,6 +31,8 @@ describe('tillReceiptHtml', () => {
     expect(html).toContain('PBJT 10%')
     expect(html).toContain('840')
     expect(html).toContain('9.240')
+    expect(html).toContain('Pembulatan')
+    expect(html).toContain('9.200')
     expect(html).toContain('Kasir Siti Kasir')
     expect(html).toContain('WIB')
     expect(html).not.toContain('Printer belum terhubung')

--- a/src/pages/pos/tillBill.ts
+++ b/src/pages/pos/tillBill.ts
@@ -5,6 +5,20 @@ export interface TillBill {
   payable: number
 }
 
+/** Nearest-unit cash rounding (half up). Unit 0 leaves the bill exact. */
+export function roundCashPayable(payable: number, unit = 100): number {
+  const amount = Math.round(Math.max(0, payable))
+  if (unit < 1) {
+    return amount
+  }
+  const remainder = ((amount % unit) + unit) % unit
+  if (remainder === 0) {
+    return amount
+  }
+
+  return remainder >= unit / 2 ? amount - remainder + unit : amount - remainder
+}
+
 export function addOnBill(subtotal: number, serviceRate: number, taxRate: number): TillBill {
   const service = Math.round(subtotal * serviceRate / 100)
   const tax = Math.round((subtotal + service) * taxRate / 100)

--- a/src/pages/pos/tillPrint.ts
+++ b/src/pages/pos/tillPrint.ts
@@ -49,13 +49,17 @@ export function tillReceiptHtml(
     return `<tr><td>${item.quantity}× ${name}</td><td style="text-align:right">${rp(item.payable_amount)}</td></tr>`
   }).join('')
 
+  const rounding = sale.rounding_amount ?? 0
+  const cashDue = sale.cash_due_amount ?? (sale.payable_amount + rounding)
   const extras = [
     `<tr><td>Subtotal</td><td style="text-align:right">${rp(subtotal)}</td></tr>`,
     service > 0 ? `<tr><td>Service ${serviceRate}%</td><td style="text-align:right">${rp(service)}</td></tr>` : '',
     tax > 0 ? `<tr><td>${taxName} ${taxRate}%</td><td style="text-align:right">${rp(tax)}</td></tr>` : '',
+    rounding !== 0 ? `<tr><td>Pembulatan</td><td style="text-align:right">${rp(rounding)}</td></tr>` : '',
   ].join('')
 
   const waktu = formatStrukWaktu(sale.sold_at)
+  const tunai = rounding !== 0 ? `<div>Tunai ${rp(cashDue)}</div>` : ''
   const bayar = sale.change_amount > 0
     ? `<div>Bayar ${rp(sale.cash_received_amount)}</div><div>Kembalian ${rp(sale.change_amount)}</div>`
     : '<div>Uang pas</div>'
@@ -76,6 +80,7 @@ export function tillReceiptHtml(
   ${cashier ? `<div class="muted">Kasir ${cashier}</div>` : ''}
   <table>${lines}${extras}</table>
   <div class="total">Total ${rp(sale.payable_amount)}</div>
+  ${tunai}
   ${bayar}
   <p class="muted">Terima kasih</p>
 </body></html>`


### PR DESCRIPTION
## Summary
Till tunai rounds to the session `cash_rounding_unit` (QRIS stays the bill).

- Pembulatan + Tunai dibayar on the pay slab
- Uang pas / change use cash due
- Struk prints Pembulatan and Tunai when rounded

Companion BE: https://github.com/satriyop/enter365/pull/50

## Test plan
- [x] `tillBill.test.ts` roundCashPayable
- [x] `tillPrint.test.ts` Air Mineral 9240 → 9200