### PR TITLE
feat(journals): Analytic + Tax Grids columns on JE lines (#40)

### DIFF
--- a/src/api/__tests__/journal-entry-dimensions.test.ts
+++ b/src/api/__tests__/journal-entry-dimensions.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import {
+  formatAnalyticDistribution,
+  parseAnalyticDistribution,
+  formatTaxTagIds,
+  parseTaxTagIds,
+} from '../useJournalEntries'
+
+describe('JE line analytic / tax grid helpers', () => {
+  it('parses and formats analytic_distribution id:pct pairs', () => {
+    expect(parseAnalyticDistribution('1:100')).toEqual({ '1': 100 })
+    expect(parseAnalyticDistribution('1:50, 2:50')).toEqual({ '1': 50, '2': 50 })
+    expect(parseAnalyticDistribution('{"10":60,"20":40}')).toEqual({ '10': 60, '20': 40 })
+    expect(parseAnalyticDistribution('')).toBeNull()
+    expect(parseAnalyticDistribution('1:150')).toBeNull()
+    expect(parseAnalyticDistribution('bad')).toBeNull()
+    expect(formatAnalyticDistribution({ '1': 100 })).toBe('1:100')
+    expect(formatAnalyticDistribution(null)).toBe('')
+  })
+
+  it('parses and formats tax_tag_ids', () => {
+    expect(parseTaxTagIds('101, 202')).toEqual([101, 202])
+    expect(parseTaxTagIds('')).toBeNull()
+    expect(parseTaxTagIds('abc')).toBeNull()
+    expect(parseTaxTagIds('0')).toBeNull()
+    expect(formatTaxTagIds([101, 202])).toBe('101, 202')
+    expect(formatTaxTagIds(null)).toBe('')
+  })
+})

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -8658,6 +8658,10 @@ export interface components {
             journal_entry_id: number;
             account_id: number;
             partner_id?: number | null;
+            /** Odoo analytic_distribution map {analytic_account_id: percentage} */
+            analytic_distribution?: { [key: string]: number } | null;
+            /** Odoo Tax Grids / tax_tag_ids */
+            tax_tag_ids?: number[] | null;
             description: string;
             debit: number;
             credit: number;
@@ -10557,6 +10561,8 @@ export interface components {
             lines: {
                 account_id: number;
                 partner_id?: number | null;
+                analytic_distribution?: { [key: string]: number } | null;
+                tax_tag_ids?: number[] | null;
                 description?: string | null;
                 debit?: number;
                 credit?: number;

--- a/src/api/useJournalEntries.ts
+++ b/src/api/useJournalEntries.ts
@@ -172,10 +172,88 @@ export function createEmptyLine(): CreateJournalEntryLineData {
   return {
     account_id: 0,
     partner_id: null,
+    analytic_distribution: null,
+    tax_tag_ids: null,
     description: '',
     debit: 0,
     credit: 0,
   }
+}
+
+/**
+ * Format Odoo analytic_distribution as "id:pct, id:pct" for the line grid.
+ */
+export function formatAnalyticDistribution(
+  value: { [key: string]: number } | null | undefined,
+): string {
+  if (!value || Object.keys(value).length === 0) return ''
+  return Object.entries(value)
+    .map(([id, pct]) => `${id}:${pct}`)
+    .join(', ')
+}
+
+/**
+ * Parse "id:pct, id:pct" (or JSON object) into analytic_distribution.
+ * Returns null when empty/invalid.
+ */
+export function parseAnalyticDistribution(
+  raw: string,
+): { [key: string]: number } | null {
+  const trimmed = raw.trim()
+  if (!trimmed) return null
+
+  if (trimmed.startsWith('{')) {
+    try {
+      const parsed = JSON.parse(trimmed) as Record<string, unknown>
+      const out: { [key: string]: number } = {}
+      for (const [k, v] of Object.entries(parsed)) {
+        const n = Number(v)
+        if (!Number.isFinite(n) || n < 0 || n > 100) return null
+        out[String(k)] = n
+      }
+      return Object.keys(out).length ? out : null
+    } catch {
+      return null
+    }
+  }
+
+  const out: { [key: string]: number } = {}
+  for (const part of trimmed.split(',')) {
+    const piece = part.trim()
+    if (!piece) continue
+    const [idRaw, pctRaw] = piece.split(':').map((s) => s.trim())
+    if (!idRaw || pctRaw === undefined) return null
+    const pct = Number(pctRaw)
+    if (!/^\d+$/.test(idRaw) || !Number.isFinite(pct) || pct < 0 || pct > 100) return null
+    out[idRaw] = pct
+  }
+  return Object.keys(out).length ? out : null
+}
+
+/**
+ * Format tax_tag_ids as comma-separated ids for the line grid.
+ */
+export function formatTaxTagIds(value: number[] | null | undefined): string {
+  if (!value || value.length === 0) return ''
+  return value.join(', ')
+}
+
+/**
+ * Parse comma-separated tax tag ids. Returns null when empty; null on invalid.
+ */
+export function parseTaxTagIds(raw: string): number[] | null {
+  const trimmed = raw.trim()
+  if (!trimmed) return null
+  const ids: number[] = []
+  for (const part of trimmed.split(',')) {
+    const piece = part.trim()
+    if (!piece) continue
+    if (!/^\d+$/.test(piece)) return null
+    const n = parseInt(piece, 10)
+    if (n < 1) return null
+    ids.push(n)
+  }
+  return ids.length ? ids : null
 }
 
 /**

--- a/src/pages/accounting/journal-entries/JournalEntryDetailPage.vue
+++ b/src/pages/accounting/journal-entries/JournalEntryDetailPage.vue
@@ -7,6 +7,8 @@ import {
   usePostJournalEntry,
   useReverseJournalEntry,
   getJournalEntryStatus,
+  formatAnalyticDistribution,
+  formatTaxTagIds,
 } from '@/api/useJournalEntries'
 import { formatCurrency, formatDate } from '@/utils/format'
 import { Button, Card, Modal, Input, useToast } from '@/components/ui'
@@ -251,6 +253,8 @@ function viewAccount(accountId: string) {
               <tr>
                 <th class="px-4 py-3 text-left font-medium text-slate-500 dark:text-slate-400">Account</th>
                 <th class="px-4 py-3 text-left font-medium text-slate-500 dark:text-slate-400">Partner</th>
+                <th class="px-4 py-3 text-left font-medium text-slate-500 dark:text-slate-400">Analytic</th>
+                <th class="px-4 py-3 text-left font-medium text-slate-500 dark:text-slate-400">Tax Grids</th>
                 <th class="px-4 py-3 text-left font-medium text-slate-500 dark:text-slate-400">Description</th>
                 <th class="px-4 py-3 text-right font-medium text-slate-500 dark:text-slate-400">Debit</th>
                 <th class="px-4 py-3 text-right font-medium text-slate-500 dark:text-slate-400">Credit</th>
@@ -279,6 +283,12 @@ function viewAccount(accountId: string) {
                   </template>
                   <template v-else>-</template>
                 </td>
+                <td class="px-4 py-3 font-mono text-slate-600 dark:text-slate-400" data-testid="je-line-analytic">
+                  {{ formatAnalyticDistribution(line.analytic_distribution) || '-' }}
+                </td>
+                <td class="px-4 py-3 font-mono text-slate-600 dark:text-slate-400" data-testid="je-line-tax-grids">
+                  {{ formatTaxTagIds(line.tax_tag_ids) || '-' }}
+                </td>
                 <td class="px-4 py-3 text-slate-600 dark:text-slate-400">
                   {{ line.description || '-' }}
                 </td>
@@ -292,7 +302,7 @@ function viewAccount(accountId: string) {
             </tbody>
             <tfoot class="bg-slate-50 dark:bg-slate-800/50 font-medium">
               <tr>
-                <td class="px-4 py-3 text-slate-900 dark:text-slate-100" colspan="3">Total</td>
+                <td class="px-4 py-3 text-slate-900 dark:text-slate-100" colspan="5">Total</td>
                 <td class="px-4 py-3 text-right font-mono text-slate-900 dark:text-slate-100">
                   {{ formatCurrency(entry.total_debit) }}
                 </td>

--- a/src/pages/accounting/journal-entries/JournalEntryFormPage.vue
+++ b/src/pages/accounting/journal-entries/JournalEntryFormPage.vue
@@ -6,6 +6,10 @@ import {
   calculateLineTotals,
   validateJournalLines,
   createEmptyLine,
+  formatAnalyticDistribution,
+  parseAnalyticDistribution,
+  formatTaxTagIds,
+  parseTaxTagIds,
   type CreateJournalEntryData,
   type CreateJournalEntryLineData,
 } from '@/api/useJournalEntries'
@@ -60,6 +64,10 @@ const lines = ref<CreateJournalEntryLineData[]>([
   createEmptyLine(),
 ])
 
+/** Draft strings for optional Odoo dimensions (no analytic/tax-tag masters yet). */
+const analyticDrafts = ref<string[]>(['', ''])
+const taxTagDrafts = ref<string[]>(['', ''])
+
 // Calculate totals
 const totals = computed(() => calculateLineTotals(lines.value))
 
@@ -75,13 +83,41 @@ const hasErrors = computed(() => validationErrors.value.length > 0)
 // Add new line
 function addLine() {
   lines.value.push(createEmptyLine())
+  analyticDrafts.value.push('')
+  taxTagDrafts.value.push('')
 }
 
 // Remove line
 function removeLine(index: number) {
   if (lines.value.length > 2) {
     lines.value.splice(index, 1)
+    analyticDrafts.value.splice(index, 1)
+    taxTagDrafts.value.splice(index, 1)
   }
+}
+
+function onAnalyticInput(index: number, value: string) {
+  analyticDrafts.value[index] = value
+  const line = lines.value[index]
+  if (!line) return
+  if (!value.trim()) {
+    line.analytic_distribution = null
+    return
+  }
+  const parsed = parseAnalyticDistribution(value)
+  if (parsed) line.analytic_distribution = parsed
+}
+
+function onTaxTagsInput(index: number, value: string) {
+  taxTagDrafts.value[index] = value
+  const line = lines.value[index]
+  if (!line) return
+  if (!value.trim()) {
+    line.tax_tag_ids = null
+    return
+  }
+  const parsed = parseTaxTagIds(value)
+  if (parsed) line.tax_tag_ids = parsed
 }
 
 // Handle debit change - clear credit if debit is entered
@@ -155,6 +191,34 @@ async function handleSubmit() {
   if (hasErrors.value) {
     toast.error('Please fix the errors before submitting')
     return
+  }
+
+  // Commit optional dimension drafts (reject half-typed values)
+  for (let i = 0; i < lines.value.length; i++) {
+    const line = lines.value[i]
+    if (!line) continue
+    const analyticRaw = analyticDrafts.value[i] ?? ''
+    if (analyticRaw.trim()) {
+      const parsed = parseAnalyticDistribution(analyticRaw)
+      if (!parsed) {
+        toast.error(`Line ${i + 1}: Analytic Distribution must be id:pct pairs (e.g. 1:100 or 1:50, 2:50)`)
+        return
+      }
+      line.analytic_distribution = parsed
+    } else {
+      line.analytic_distribution = null
+    }
+    const taxRaw = taxTagDrafts.value[i] ?? ''
+    if (taxRaw.trim()) {
+      const parsed = parseTaxTagIds(taxRaw)
+      if (!parsed) {
+        toast.error(`Line ${i + 1}: Tax Grids must be comma-separated positive ids (e.g. 101, 202)`)
+        return
+      }
+      line.tax_tag_ids = parsed
+    } else {
+      line.tax_tag_ids = null
+    }
   }
 
   // Filter out empty lines
@@ -274,8 +338,14 @@ async function handleSubmit() {
                 <th class="px-4 py-3 text-left font-medium text-slate-500 dark:text-slate-400 w-1/4">
                   Account <span class="text-red-500">*</span>
                 </th>
-                <th class="px-4 py-3 text-left font-medium text-slate-500 dark:text-slate-400 w-1/5">
+                <th class="px-4 py-3 text-left font-medium text-slate-500 dark:text-slate-400 min-w-[9rem]">
                   Partner
+                </th>
+                <th class="px-4 py-3 text-left font-medium text-slate-500 dark:text-slate-400 min-w-[8rem]" title="Odoo analytic_distribution — id:pct (no analytic master yet)">
+                  Analytic
+                </th>
+                <th class="px-4 py-3 text-left font-medium text-slate-500 dark:text-slate-400 min-w-[7rem]" title="Odoo Tax Grids / tax_tag_ids (no tax-tag master yet)">
+                  Tax Grids
                 </th>
                 <th class="px-4 py-3 text-left font-medium text-slate-500 dark:text-slate-400 w-1/5">
                   Description
@@ -312,6 +382,28 @@ async function handleSubmit() {
                     :loading="contactsLoading"
                     placeholder="Optional"
                     @update:model-value="(v) => line.partner_id = v ? parseInt(String(v), 10) : null"
+                  />
+                </td>
+
+                <!-- Analytic Distribution -->
+                <td class="px-4 py-2">
+                  <Input
+                    :model-value="analyticDrafts[index] ?? formatAnalyticDistribution(line.analytic_distribution)"
+                    :data-testid="`je-line-${index}-analytic`"
+                    placeholder="1:100"
+                    class="text-sm font-mono"
+                    @update:model-value="(v) => onAnalyticInput(index, String(v))"
+                  />
+                </td>
+
+                <!-- Tax Grids -->
+                <td class="px-4 py-2">
+                  <Input
+                    :model-value="taxTagDrafts[index] ?? formatTaxTagIds(line.tax_tag_ids)"
+                    :data-testid="`je-line-${index}-tax-grids`"
+                    placeholder="101, 202"
+                    class="text-sm font-mono"
+                    @update:model-value="(v) => onTaxTagsInput(index, String(v))"
                   />
                 </td>
 
@@ -363,7 +455,7 @@ async function handleSubmit() {
             </tbody>
             <tfoot class="bg-slate-50 dark:bg-slate-800/50 font-medium">
               <tr>
-                <td class="px-4 py-3 text-slate-900 dark:text-slate-100" colspan="3">Total</td>
+                <td class="px-4 py-3 text-slate-900 dark:text-slate-100" colspan="5">Total</td>
                 <td class="px-4 py-3 text-right font-mono text-slate-900 dark:text-slate-100">
                   {{ formatCurrency(totals.totalDebit) }}
                 </td>
@@ -430,6 +522,8 @@ async function handleSubmit() {
       </template>
       <ul class="text-sm text-slate-600 dark:text-slate-400 space-y-2">
         <li>• Partner (customer/vendor) is optional on each line for AR/AP reporting</li>
+        <li>• Analytic: optional id:pct pairs (e.g. 1:100) — stored as Odoo analytic_distribution JSON until an analytic master exists</li>
+        <li>• Tax Grids: optional comma-separated tag ids — stored as tax_tag_ids; VAT reports remain document-level for now</li>
         <li>• Each line can only have a debit OR credit amount, not both</li>
         <li>• Total debits must equal total credits for a balanced entry</li>
         <li>• Use "Auto-Balance" to automatically fill the last line</li>


### PR DESCRIPTION
## Summary
SPA companion for enter365 JE line Analytic Distribution + Tax Grids (residual after Partner / #27).

**Fixes satriyop/enter365#40** (with API PR https://github.com/satriyop/enter365/pull/56).

### UI
- Jurnal create grid: optional **Analytic** (`id:pct` → `analytic_distribution`) and **Tax Grids** (comma-separated ids → `tax_tag_ids`).
- Detail grid shows the same columns.
- Helpers + Vitest for parse/format (no analytic/tax-tag masters yet — free-text entry).

### API dependency
Requires enter365 #56 (nullable JSON columns + OpenAPI).

Does not touch journal bank/cash payment account pickers (#34 / FE#38).

## Test plan
- [ ] CI Vitest `journal-entry-dimensions.test.ts`
- [ ] With API branch: create JE with Analytic `1:100` and Tax Grids `101, 202`; detail shows values
- [ ] Empty optional fields still create successfully