### PR TITLE
feat(search): hide Invoices when the invoices pack is off (#28)

### DIFF
--- a/src/components/CommandPalette.vue
+++ b/src/components/CommandPalette.vue
@@ -33,6 +33,8 @@ import {
 } from 'lucide-vue-next'
 import { useRecentlyViewed, type RecentlyViewedItem } from '@/composables/useRecentlyViewed'
 import { useGlobalSearch } from '@/api/useGlobalSearch'
+import { searchResultVisible } from '@/config/searchCatalog'
+import { useFeaturesStore } from '@/stores/features'
 
 // Types
 interface QuickAction {
@@ -44,6 +46,7 @@ interface QuickAction {
   path?: string
   action?: () => void
   shortcut?: string
+  feature?: string
 }
 
 const props = defineProps<{
@@ -56,6 +59,7 @@ const emit = defineEmits<{
 }>()
 
 const router = useRouter()
+const features = useFeaturesStore()
 const { items: recentItems } = useRecentlyViewed()
 
 // State
@@ -89,20 +93,24 @@ watch(searchQuery, (val) => {
 // Use global search hook
 const { data: searchResultsData, isLoading: isSearching } = useGlobalSearch(debouncedQuery)
 
-const searchResults = computed(() => searchResultsData.value || [])
+const searchResults = computed(() =>
+  (searchResultsData.value || []).filter((row) =>
+    searchResultVisible(row.type, (name) => features.enabled(name)),
+  ),
+)
 
 // Quick actions / navigation
 const quickActions = computed<QuickAction[]>(() => [
   { id: 'home', type: 'navigation', title: 'Dashboard', subtitle: 'Go to home', icon: Home, path: '/', shortcut: 'G H' },
-  { id: 'quotations', type: 'navigation', title: 'Quotations', subtitle: 'View all quotations', icon: FileText, path: '/quotations', shortcut: 'G Q' },
-  { id: 'invoices', type: 'navigation', title: 'Invoices', subtitle: 'View all invoices', icon: Receipt, path: '/invoices', shortcut: 'G I' },
+  { id: 'quotations', type: 'navigation', title: 'Quotations', subtitle: 'View all quotations', icon: FileText, path: '/quotations', shortcut: 'G Q', feature: 'quotations' },
+  { id: 'invoices', type: 'navigation', title: 'Invoices', subtitle: 'View all invoices', icon: Receipt, path: '/invoices', shortcut: 'G I', feature: 'invoices' },
   { id: 'contacts', type: 'navigation', title: 'Contacts', subtitle: 'View all contacts', icon: Users, path: '/contacts', shortcut: 'G C' },
   { id: 'products', type: 'navigation', title: 'Products', subtitle: 'View all products', icon: Package, path: '/products', shortcut: 'G P' },
-  { id: 'boms', type: 'navigation', title: 'Bill of Materials', subtitle: 'View all BOMs', icon: Layers, path: '/boms', shortcut: 'G B' },
-  { id: 'solar', type: 'navigation', title: 'Solar Proposals', subtitle: 'View solar proposals', icon: Sun, path: '/solar-proposals' },
+  { id: 'boms', type: 'navigation', title: 'Bill of Materials', subtitle: 'View all BOMs', icon: Layers, path: '/boms', shortcut: 'G B', feature: 'bom' },
+  { id: 'solar', type: 'navigation', title: 'Solar Proposals', subtitle: 'View solar proposals', icon: Sun, path: '/solar-proposals', feature: 'solar_proposals' },
   { id: 'settings', type: 'navigation', title: 'Settings', subtitle: 'App settings', icon: Settings, path: '/settings' },
   { id: 'shortcuts', type: 'action', title: 'Keyboard Shortcuts', subtitle: 'View all shortcuts', icon: Keyboard, action: () => { isOpen.value = false; emit('show-shortcuts') }, shortcut: '?' },
-])
+].filter((action) => !action.feature || features.enabled(action.feature)))
 
 const typeIcons: Record<string, typeof Home> = {
   quotation: FileText,

--- a/src/components/GlobalSearch.vue
+++ b/src/components/GlobalSearch.vue
@@ -4,11 +4,17 @@ import { useRouter } from 'vue-router'
 import { useQuery } from '@tanstack/vue-query'
 import { api } from '@/api/client'
 import { posChrome } from '@/config/nav'
+import {
+  SEARCH_NAV_ITEMS,
+  SEARCH_QUICK_ACTIONS,
+  catalogVisible,
+  searchResultVisible,
+} from '@/config/searchCatalog'
 import { useFeaturesStore } from '@/stores/features'
 
 const router = useRouter()
 const features = useFeaturesStore()
-const posPack = computed(() => features.preset === 'pos')
+const posPack = computed(() => features.posAcquisition)
 const isOpen = ref(false)
 const searchQuery = ref('')
 const selectedIndex = ref(0)
@@ -23,27 +29,13 @@ interface SearchItem {
   subtitle?: string
 }
 
-// Quick navigation items (always shown)
-const quickActions: SearchItem[] = [
-  { type: 'action', label: 'New Quotation', icon: '📝', path: '/quotations/new' },
-  { type: 'action', label: 'New Invoice', icon: '📄', path: '/invoices/new' },
-  { type: 'action', label: 'New Contact', icon: '👤', path: '/contacts/new' },
-  { type: 'action', label: 'New Project', icon: '🏗️', path: '/projects/new' },
-  { type: 'action', label: 'New Work Order', icon: '🔧', path: '/work-orders/new' },
-]
+const quickActions = computed(() =>
+  catalogVisible(SEARCH_QUICK_ACTIONS, (name) => features.enabled(name)),
+)
 
-const navigationItems: SearchItem[] = [
-  { type: 'nav', label: 'Dashboard', icon: '🏠', path: '/' },
-  { type: 'nav', label: 'Quotations', icon: '📝', path: '/quotations' },
-  { type: 'nav', label: 'Invoices', icon: '📄', path: '/invoices' },
-  { type: 'nav', label: 'Bills', icon: '📋', path: '/bills' },
-  { type: 'nav', label: 'Contacts', icon: '👤', path: '/contacts' },
-  { type: 'nav', label: 'Products', icon: '📦', path: '/products' },
-  { type: 'nav', label: 'Projects', icon: '🏗️', path: '/projects' },
-  { type: 'nav', label: 'Work Orders', icon: '🔧', path: '/work-orders' },
-  { type: 'nav', label: 'Inventory', icon: '📊', path: '/inventory' },
-  { type: 'nav', label: 'Reports', icon: '📈', path: '/reports' },
-]
+const navigationItems = computed(() =>
+  catalogVisible(SEARCH_NAV_ITEMS, (name) => features.enabled(name)),
+)
 
 // Search API
 const { data: searchResults, isFetching } = useQuery({
@@ -72,19 +64,19 @@ const displayItems = computed(() => {
   if (!query) {
     return [
       { type: 'group', label: 'Quick Actions' } as SearchItem,
-      ...quickActions,
+      ...quickActions.value,
       { type: 'group', label: 'Navigation' } as SearchItem,
-      ...navigationItems,
+      ...navigationItems.value,
     ]
   }
 
   const items: SearchItem[] = []
 
   // Filter navigation and actions by query
-  const filteredActions = quickActions.filter(item =>
+  const filteredActions = quickActions.value.filter(item =>
     item.label.toLowerCase().includes(query)
   )
-  const filteredNav = navigationItems.filter(item =>
+  const filteredNav = navigationItems.value.filter(item =>
     item.label.toLowerCase().includes(query)
   )
 
@@ -128,7 +120,7 @@ const displayItems = computed(() => {
       })
     }
 
-    if (quotations?.length) {
+    if (quotations?.length && features.enabled('quotations')) {
       items.push({ type: 'group' as const, label: 'Quotations' })
       quotations.slice(0, 5).forEach(q => {
         items.push({
@@ -141,7 +133,7 @@ const displayItems = computed(() => {
       })
     }
 
-    if (invoices?.length) {
+    if (invoices?.length && searchResultVisible('invoice', (name) => features.enabled(name))) {
       items.push({ type: 'group' as const, label: 'Invoices' })
       invoices.slice(0, 5).forEach(i => {
         items.push({
@@ -154,7 +146,7 @@ const displayItems = computed(() => {
       })
     }
 
-    if (projects?.length) {
+    if (projects?.length && features.enabled('projects')) {
       items.push({ type: 'group' as const, label: 'Projects' })
       projects.slice(0, 5).forEach(p => {
         items.push({

--- a/src/components/ui/Breadcrumbs.vue
+++ b/src/components/ui/Breadcrumbs.vue
@@ -13,7 +13,7 @@ interface BreadcrumbItem {
 const route = useRoute()
 const router = useRouter()
 const features = useFeaturesStore()
-const posPack = computed(() => features.preset === 'pos')
+const posPack = computed(() => features.posAcquisition)
 
 function crumb(label: string): string {
   return posChrome(label, posPack.value, POS_BREADCRUMB_ID)

--- a/src/components/ui/__tests__/Breadcrumbs.test.ts
+++ b/src/components/ui/__tests__/Breadcrumbs.test.ts
@@ -30,6 +30,7 @@ vi.mock('vue-router', () => ({
 vi.mock('@/stores/features', () => ({
   useFeaturesStore: () => ({
     preset: 'general',
+    posAcquisition: false,
   }),
 }))
 

--- a/src/config/__tests__/searchCatalog.test.ts
+++ b/src/config/__tests__/searchCatalog.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import {
+  SEARCH_NAV_ITEMS,
+  SEARCH_QUICK_ACTIONS,
+  catalogVisible,
+  isPosAcquisitionPreset,
+  searchResultVisible,
+} from '../searchCatalog'
+
+describe('search catalog pack gating', () => {
+  it('hides Invoices and New Invoice when the invoices pack is off', () => {
+    const enabled = (feature: string) => feature !== 'invoices'
+
+    const actions = catalogVisible(SEARCH_QUICK_ACTIONS, enabled)
+    const nav = catalogVisible(SEARCH_NAV_ITEMS, enabled)
+
+    expect(actions.map((item) => item.label)).not.toContain('New Invoice')
+    expect(nav.map((item) => item.label)).not.toContain('Invoices')
+    expect(actions.map((item) => item.label)).toContain('New Contact')
+    expect(searchResultVisible('invoice', enabled)).toBe(false)
+    expect(searchResultVisible('contact', enabled)).toBe(true)
+  })
+
+  it('shows Invoices when the invoices pack is on', () => {
+    const enabled = () => true
+
+    expect(catalogVisible(SEARCH_QUICK_ACTIONS, enabled).map((item) => item.label))
+      .toContain('New Invoice')
+    expect(catalogVisible(SEARCH_NAV_ITEMS, enabled).map((item) => item.label))
+      .toContain('Invoices')
+    expect(searchResultVisible('invoice', enabled)).toBe(true)
+  })
+
+  it('treats parity as a POS-acquisition preset', () => {
+    expect(isPosAcquisitionPreset('pos')).toBe(true)
+    expect(isPosAcquisitionPreset('parity')).toBe(true)
+    expect(isPosAcquisitionPreset('general')).toBe(false)
+  })
+})

--- a/src/config/searchCatalog.ts
+++ b/src/config/searchCatalog.ts
@@ -1,0 +1,55 @@
+export interface SearchCatalogItem {
+  type: 'action' | 'nav'
+  label: string
+  icon: string
+  path: string
+  feature?: string
+}
+
+export const SEARCH_QUICK_ACTIONS: SearchCatalogItem[] = [
+  { type: 'action', label: 'New Quotation', icon: '📝', path: '/quotations/new', feature: 'quotations' },
+  { type: 'action', label: 'New Invoice', icon: '📄', path: '/invoices/new', feature: 'invoices' },
+  { type: 'action', label: 'New Contact', icon: '👤', path: '/contacts/new' },
+  { type: 'action', label: 'New Project', icon: '🏗️', path: '/projects/new', feature: 'projects' },
+  { type: 'action', label: 'New Work Order', icon: '🔧', path: '/work-orders/new', feature: 'work_orders' },
+]
+
+export const SEARCH_NAV_ITEMS: SearchCatalogItem[] = [
+  { type: 'nav', label: 'Dashboard', icon: '🏠', path: '/' },
+  { type: 'nav', label: 'Quotations', icon: '📝', path: '/quotations', feature: 'quotations' },
+  { type: 'nav', label: 'Invoices', icon: '📄', path: '/invoices', feature: 'invoices' },
+  { type: 'nav', label: 'Bills', icon: '📋', path: '/bills' },
+  { type: 'nav', label: 'Contacts', icon: '👤', path: '/contacts' },
+  { type: 'nav', label: 'Products', icon: '📦', path: '/products' },
+  { type: 'nav', label: 'Projects', icon: '🏗️', path: '/projects', feature: 'projects' },
+  { type: 'nav', label: 'Work Orders', icon: '🔧', path: '/work-orders', feature: 'work_orders' },
+  { type: 'nav', label: 'Inventory', icon: '📊', path: '/inventory', feature: 'inventory' },
+  { type: 'nav', label: 'Reports', icon: '📈', path: '/reports' },
+]
+
+export const SEARCH_RESULT_FEATURES: Record<string, string> = {
+  invoice: 'invoices',
+  quotation: 'quotations',
+  bom: 'bom',
+  project: 'projects',
+  solar_proposal: 'solar_proposals',
+}
+
+export function catalogVisible(
+  items: SearchCatalogItem[],
+  enabled: (feature: string) => boolean,
+): SearchCatalogItem[] {
+  return items.filter((item) => !item.feature || enabled(item.feature))
+}
+
+export function searchResultVisible(
+  type: string,
+  enabled: (feature: string) => boolean,
+): boolean {
+  const feature = SEARCH_RESULT_FEATURES[type]
+  return !feature || enabled(feature)
+}
+
+export function isPosAcquisitionPreset(preset: string | undefined | null): boolean {
+  return preset === 'pos' || preset === 'parity'
+}

--- a/src/layouts/AppHeader.vue
+++ b/src/layouts/AppHeader.vue
@@ -14,7 +14,7 @@ defineEmits<{
 
 const auth = useAuthStore()
 const features = useFeaturesStore()
-const posPack = computed(() => features.preset === 'pos')
+const posPack = computed(() => features.posAcquisition)
 const showUserMenu = ref(false)
 const menuRoot = ref<HTMLElement | null>(null)
 

--- a/src/layouts/AppSidebar.vue
+++ b/src/layouts/AppSidebar.vue
@@ -46,7 +46,7 @@ const filteredNavigation = computed(() => {
   })).filter(group => group.items.length > 0)
 })
 
-const posPack = computed(() => features.preset === 'pos')
+const posPack = computed(() => features.posAcquisition)
 
 function groupLabel(label: string): string {
   return posChrome(label, posPack.value, POS_GROUP_ID)

--- a/src/pages/DashboardPage.vue
+++ b/src/pages/DashboardPage.vue
@@ -13,7 +13,7 @@ import PosShopHome from '@/pages/dashboard/PosShopHome.vue'
 
 const auth = useAuthStore()
 const features = useFeaturesStore()
-const posPack = computed(() => features.preset === 'pos')
+const posPack = computed(() => features.posAcquisition)
 const route = useRoute()
 const router = useRouter()
 const toast = useToast()
@@ -54,7 +54,7 @@ onMounted(() => {
   const label = PACK_LABELS[pack] ?? pack
   toast.warning({
     title: 'Modul tidak aktif',
-    message: features.preset === 'pos'
+    message: features.posAcquisition
       ? `${label} tidak dipakai toko ini.`
       : `${label} dimatikan di konfigurasi produk (FEATURE_PRESET / pack). Nyalakan di .env bila diperlukan.`,
     duration: 8000,

--- a/src/pages/accounting/accounts/AccountListPage.vue
+++ b/src/pages/accounting/accounts/AccountListPage.vue
@@ -18,7 +18,7 @@ import AccountTreeNode from './AccountTreeNode.vue'
 const router = useRouter()
 const toast = useToast()
 const features = useFeaturesStore()
-const posPack = computed(() => features.preset === 'pos')
+const posPack = computed(() => features.posAcquisition)
 
 // Fetch all accounts for tree
 const { data: accountsData, isLoading, error, refetch } = useAccountsTree()

--- a/src/pages/accounting/journal-entries/JournalEntryListPage.vue
+++ b/src/pages/accounting/journal-entries/JournalEntryListPage.vue
@@ -21,7 +21,7 @@ import { Plus, Search, FileText, Calendar } from 'lucide-vue-next'
 const router = useRouter()
 const toast = useToast()
 const features = useFeaturesStore()
-const posPack = computed(() => features.preset === 'pos')
+const posPack = computed(() => features.posAcquisition)
 const title = computed(() => posChrome('Journal Entries', posPack.value, POS_NAV_ID))
 
 const { data: contacts, isLoading: contactsLoading } = useContactsLookup()

--- a/src/pages/inventory/InventoryListPage.vue
+++ b/src/pages/inventory/InventoryListPage.vue
@@ -8,7 +8,7 @@ import { POS_NAV_ID, posChrome } from '@/config/nav'
 import { useFeaturesStore } from '@/stores/features'
 
 const features = useFeaturesStore()
-const posPack = computed(() => features.preset === 'pos')
+const posPack = computed(() => features.posAcquisition)
 
 // Resource list with filters and pagination
 const {

--- a/src/pages/inventory/StockAdjustmentPage.vue
+++ b/src/pages/inventory/StockAdjustmentPage.vue
@@ -14,7 +14,7 @@ import { useFeaturesStore } from '@/stores/features'
 const router = useRouter()
 const toast = useToast()
 const features = useFeaturesStore()
-const posPack = computed(() => features.preset === 'pos')
+const posPack = computed(() => features.posAcquisition)
 
 // Adjustment type
 const adjustmentType = ref<'adjust' | 'in' | 'out'>('adjust')

--- a/src/pages/products/ProductDetailPage.vue
+++ b/src/pages/products/ProductDetailPage.vue
@@ -10,7 +10,7 @@ import { useFeaturesStore } from '@/stores/features'
 import { Pencil, Trash2, Copy, ArrowLeft, Scale } from 'lucide-vue-next'
 
 const features = useFeaturesStore()
-const posPack = computed(() => features.preset === 'pos')
+const posPack = computed(() => features.posAcquisition)
 
 const route = useRoute()
 const router = useRouter()

--- a/src/pages/products/ProductListPage.vue
+++ b/src/pages/products/ProductListPage.vue
@@ -14,7 +14,7 @@ import { useFeaturesStore } from '@/stores/features'
 import { Download, Plus } from 'lucide-vue-next'
 
 const features = useFeaturesStore()
-const posPack = computed(() => features.preset === 'pos')
+const posPack = computed(() => features.posAcquisition)
 
 const toast = useToast()
 const route = useRoute()

--- a/src/stores/features.ts
+++ b/src/stores/features.ts
@@ -1,6 +1,7 @@
 import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
 import { api } from '@/api/client'
+import { isPosAcquisitionPreset } from '@/config/searchCatalog'
 
 /**
  * Backend product modules (config/features.php).
@@ -42,6 +43,8 @@ export const useFeaturesStore = defineStore('features', () => {
       .filter(([, on]) => on)
       .map(([name]) => name),
   )
+
+  const posAcquisition = computed(() => isPosAcquisitionPreset(preset.value))
 
   /**
    * Whether a product module is enabled.
@@ -106,6 +109,7 @@ export const useFeaturesStore = defineStore('features', () => {
   return {
     modules,
     preset,
+    posAcquisition,
     loaded,
     loading,
     enabledList,


### PR DESCRIPTION
## Summary
- Global search and the command palette no longer advertise **Invoices** / **New Invoice** when `feature:invoices` is off (live Kopitiam toast was the pack, but search still listed the journey).
- `FEATURE_PRESET=parity` uses the same POS chrome as `pos` (Indonesian till labels).
- Vitest: `searchCatalog.test.ts` asserts Invoices drop out when the pack is disabled.

Companion BE: https://github.com/satriyop/enter365/pull/63

Related to satriyop/enter365#28.

## Test plan
- [ ] CI Vitest `searchCatalog.test.ts`
- [ ] With invoices off: Cmd+K / search must not list Invoices
- [ ] With invoices on (parity or FEATURE_INVOICES): Invoices + New Invoice appear

## Notes
Do not merge (this batch is open-PR only).