### PR TITLE
feat(reports): Export on cash flow, equity, daily cash + journal filters (#37)

### DIFF
--- a/src/api/useExports.ts
+++ b/src/api/useExports.ts
@@ -79,12 +79,57 @@ export function useExportIncomeStatement() {
  */
 export function useExportGeneralLedger() {
   return useMutation({
-    mutationFn: async (params?: { account_id?: string; start_date?: string; end_date?: string }) => {
+    mutationFn: async (params?: {
+      account_id?: string
+      start_date?: string
+      end_date?: string
+      journal_id?: string
+      analytic_account_id?: string
+    }) => {
       const response = await api.get('/export/general-ledger', {
         params: { format: 'csv', ...params },
         responseType: 'blob',
       })
       downloadBlob(response.data, `general-ledger-${params?.start_date || today()}.csv`)
+      return true
+    },
+  })
+}
+
+export function useExportCashFlow() {
+  return useMutation({
+    mutationFn: async (params?: { start_date?: string; end_date?: string }) => {
+      const response = await api.get('/export/cash-flow', {
+        params: { format: 'csv', ...params },
+        responseType: 'blob',
+      })
+      downloadBlob(response.data, `cash-flow-${params?.start_date || today()}.csv`)
+      return true
+    },
+  })
+}
+
+export function useExportChangesInEquity() {
+  return useMutation({
+    mutationFn: async (params?: { start_date?: string; end_date?: string }) => {
+      const response = await api.get('/export/changes-in-equity', {
+        params: { format: 'csv', ...params },
+        responseType: 'blob',
+      })
+      downloadBlob(response.data, `changes-in-equity-${params?.start_date || today()}.csv`)
+      return true
+    },
+  })
+}
+
+export function useExportDailyCashMovement() {
+  return useMutation({
+    mutationFn: async (params?: { start_date?: string; end_date?: string }) => {
+      const response = await api.get('/export/daily-cash-movement', {
+        params: { format: 'csv', ...params },
+        responseType: 'blob',
+      })
+      downloadBlob(response.data, `daily-cash-movement-${params?.start_date || today()}.csv`)
       return true
     },
   })

--- a/src/api/useReports.ts
+++ b/src/api/useReports.ts
@@ -46,6 +46,14 @@ export interface BalanceSheetReport {
   total_equity: number
   total_liabilities_equity: number
   is_balanced: boolean
+  variance?: {
+    assets_change: number
+    assets_change_percent: number
+    liabilities_change: number
+    liabilities_change_percent: number
+    equity_change: number
+    equity_change_percent: number
+  }
 }
 
 export interface IncomeStatementSection {
@@ -70,6 +78,14 @@ export interface IncomeStatementReport {
   net_income: number
   gross_profit?: number
   operating_income?: number
+  variance?: {
+    revenue_change: number
+    revenue_change_percent: number
+    expenses_change: number
+    expenses_change_percent: number
+    net_income_change: number
+    net_income_change_percent: number
+  }
 }
 
 export interface CashFlowCategory {
@@ -93,6 +109,11 @@ export interface CashFlowReport {
   net_cash_change: number
   opening_balance: number
   closing_balance: number
+  variance?: {
+    net_cash_change: number
+    opening_balance_change: number
+    closing_balance_change: number
+  }
 }
 
 export interface AgingBucket {
@@ -150,6 +171,8 @@ export interface GeneralLedgerReport {
   report_name: string
   start_date: string
   end_date: string
+  journal_id?: number | null
+  analytic_account_id?: number | null
   accounts: GeneralLedgerAccount[]
 }
 
@@ -214,7 +237,8 @@ export interface DailyCashMovement {
   receipts: number
   payments: number
   net: number
-  running_balance: number
+  running_balance?: number
+  balance?: number
 }
 
 export interface DailyCashMovementReport {
@@ -781,11 +805,16 @@ export interface BankReconciliationReport {
 // Hooks
 // ─────────────────────────────────────────────────────────────
 
-export function useTrialBalance(asOfDate?: Ref<string | undefined>) {
+export function useTrialBalance(
+  asOfDate?: Ref<string | undefined>,
+  journalId?: Ref<string | undefined>
+) {
   return useQuery({
-    queryKey: ['reports', 'trial-balance', asOfDate],
+    queryKey: ['reports', 'trial-balance', asOfDate, journalId],
     queryFn: async () => {
-      const params = asOfDate?.value ? { as_of_date: asOfDate.value } : {}
+      const params: Record<string, string> = {}
+      if (asOfDate?.value) params.as_of_date = asOfDate.value
+      if (journalId?.value) params.journal_id = journalId.value
       const response = await api.get<{ data: TrialBalanceReport }>('/reports/trial-balance', { params })
       return response.data.data
     },
@@ -793,13 +822,29 @@ export function useTrialBalance(asOfDate?: Ref<string | undefined>) {
   })
 }
 
-export function useBalanceSheet(asOfDate?: Ref<string | undefined>) {
+export function useBalanceSheet(
+  asOfDate?: Ref<string | undefined>,
+  compareTo?: Ref<string | undefined>
+) {
   return useQuery({
-    queryKey: ['reports', 'balance-sheet', asOfDate],
+    queryKey: ['reports', 'balance-sheet', asOfDate, compareTo],
     queryFn: async () => {
-      const params = asOfDate?.value ? { as_of_date: asOfDate.value } : {}
-      const response = await api.get<{ data: BalanceSheetReport }>('/reports/balance-sheet', { params })
-      return response.data.data
+      const params: Record<string, string> = {}
+      if (asOfDate?.value) params.as_of_date = asOfDate.value
+      if (compareTo?.value) params.compare_to = compareTo.value
+      const response = await api.get<{ data: BalanceSheetReport & {
+        current_period?: BalanceSheetReport
+        variance?: BalanceSheetReport['variance']
+      } }>('/reports/balance-sheet', { params })
+      const raw = response.data.data
+      if (raw.current_period) {
+        return {
+          ...raw.current_period,
+          report_name: raw.report_name,
+          variance: raw.variance,
+        }
+      }
+      return raw
     },
     staleTime: 5 * 60 * 1000,
   })
@@ -807,16 +852,29 @@ export function useBalanceSheet(asOfDate?: Ref<string | undefined>) {
 
 export function useIncomeStatement(
   startDate?: Ref<string | undefined>,
-  endDate?: Ref<string | undefined>
+  endDate?: Ref<string | undefined>,
+  comparePreviousPeriod?: Ref<boolean>
 ) {
   return useQuery({
-    queryKey: ['reports', 'income-statement', startDate, endDate],
+    queryKey: ['reports', 'income-statement', startDate, endDate, comparePreviousPeriod],
     queryFn: async () => {
       const params: Record<string, string> = {}
       if (startDate?.value) params.start_date = startDate.value
       if (endDate?.value) params.end_date = endDate.value
-      const response = await api.get<{ data: IncomeStatementReport }>('/reports/income-statement', { params })
-      return response.data.data
+      if (comparePreviousPeriod?.value) params.compare_previous_period = '1'
+      const response = await api.get<{ data: IncomeStatementReport & {
+        current_period?: IncomeStatementReport
+        variance?: IncomeStatementReport['variance']
+      } }>('/reports/income-statement', { params })
+      const raw = response.data.data
+      if (raw.current_period) {
+        return {
+          ...raw.current_period,
+          report_name: raw.report_name,
+          variance: raw.variance,
+        }
+      }
+      return raw
     },
     staleTime: 5 * 60 * 1000,
   })
@@ -824,16 +882,29 @@ export function useIncomeStatement(
 
 export function useCashFlow(
   startDate?: Ref<string | undefined>,
-  endDate?: Ref<string | undefined>
+  endDate?: Ref<string | undefined>,
+  comparePreviousPeriod?: Ref<boolean>
 ) {
   return useQuery({
-    queryKey: ['reports', 'cash-flow', startDate, endDate],
+    queryKey: ['reports', 'cash-flow', startDate, endDate, comparePreviousPeriod],
     queryFn: async () => {
       const params: Record<string, string> = {}
       if (startDate?.value) params.start_date = startDate.value
       if (endDate?.value) params.end_date = endDate.value
-      const response = await api.get<{ data: CashFlowReport }>('/reports/cash-flow', { params })
-      return response.data.data
+      if (comparePreviousPeriod?.value) params.compare_previous_period = '1'
+      const response = await api.get<{ data: CashFlowReport & {
+        current_period?: CashFlowReport
+        variance?: CashFlowReport['variance']
+      } }>('/reports/cash-flow', { params })
+      const raw = response.data.data
+      if (raw.current_period) {
+        return {
+          ...raw.current_period,
+          report_name: raw.report_name,
+          variance: raw.variance,
+        }
+      }
+      return raw
     },
     staleTime: 5 * 60 * 1000,
   })
@@ -865,14 +936,18 @@ export function usePayablesAging(asOfDate?: Ref<string | undefined>) {
 
 export function useGeneralLedger(
   startDate?: Ref<string | undefined>,
-  endDate?: Ref<string | undefined>
+  endDate?: Ref<string | undefined>,
+  journalId?: Ref<string | undefined>,
+  analyticAccountId?: Ref<string | undefined>
 ) {
   return useQuery({
-    queryKey: ['reports', 'general-ledger', startDate, endDate],
+    queryKey: ['reports', 'general-ledger', startDate, endDate, journalId, analyticAccountId],
     queryFn: async () => {
       const params: Record<string, string> = {}
       if (startDate?.value) params.start_date = startDate.value
       if (endDate?.value) params.end_date = endDate.value
+      if (journalId?.value) params.journal_id = journalId.value
+      if (analyticAccountId?.value) params.analytic_account_id = analyticAccountId.value
       const response = await api.get<{ data: GeneralLedgerReport }>('/reports/general-ledger', { params })
       return response.data.data
     },

--- a/src/pages/reports/BalanceSheetPage.vue
+++ b/src/pages/reports/BalanceSheetPage.vue
@@ -9,9 +9,11 @@ import { formatCurrency, toLocalISODate } from '@/utils/format'
 const router = useRouter()
 
 const asOfDate = ref(toLocalISODate())
+const compareTo = ref('')
 const asOfDateRef = computed(() => asOfDate.value)
+const compareToRef = computed(() => compareTo.value || undefined)
 
-const { data: report, isLoading, error } = useBalanceSheet(asOfDateRef)
+const { data: report, isLoading, error } = useBalanceSheet(asOfDateRef, compareToRef)
 
 const exportMutation = useExportBalanceSheet()
 
@@ -44,6 +46,10 @@ function formatAmount(amount: number): string {
         <div>
           <label class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">As of Date</label>
           <Input v-model="asOfDate" type="date" class="w-40" />
+        </div>
+        <div>
+          <label class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">Compare to</label>
+          <Input v-model="compareTo" type="date" class="w-40" />
         </div>
         <div class="flex gap-2">
           <Button
@@ -94,6 +100,10 @@ function formatAmount(amount: number): string {
         <div class="text-center border-b border-slate-200 dark:border-slate-700 pb-4 mb-4">
           <h2 class="text-xl font-semibold text-slate-900 dark:text-slate-100">{{ report.report_name }}</h2>
           <p class="text-slate-500 dark:text-slate-400">As of {{ report.as_of_date }}</p>
+          <p v-if="report.variance" class="text-sm text-slate-600 dark:text-slate-300 mt-2">
+            vs compare date: assets {{ formatAmount(report.variance.assets_change) }},
+            equity {{ formatAmount(report.variance.equity_change) }}
+          </p>
           <Badge v-if="report.is_balanced" variant="success" class="mt-2">Balanced</Badge>
           <Badge v-else variant="destructive" class="mt-2">Not Balanced</Badge>
         </div>

--- a/src/pages/reports/CashFlowPage.vue
+++ b/src/pages/reports/CashFlowPage.vue
@@ -2,18 +2,30 @@
 import { ref, computed } from 'vue'
 import { useRouter } from 'vue-router'
 import { useCashFlow } from '@/api/useReports'
-import { Button, Input, Card } from '@/components/ui'
+import { useExportCashFlow } from '@/api/useExports'
+import { Button, Input, Card, ExportButton } from '@/components/ui'
 import { formatCurrency, toLocalISODate } from '@/utils/format'
 
 const router = useRouter()
 
 const startDate = ref(toLocalISODate(new Date(new Date().getFullYear(), new Date().getMonth(), 1)))
 const endDate = ref(toLocalISODate())
+const comparePreviousPeriod = ref(false)
 
 const startDateRef = computed(() => startDate.value)
 const endDateRef = computed(() => endDate.value)
+const comparePreviousPeriodRef = computed(() => comparePreviousPeriod.value)
 
-const { data: report, isLoading, error } = useCashFlow(startDateRef, endDateRef)
+const { data: report, isLoading, error } = useCashFlow(startDateRef, endDateRef, comparePreviousPeriodRef)
+
+const exportMutation = useExportCashFlow()
+
+function handleExport() {
+  exportMutation.mutate({
+    start_date: startDate.value || undefined,
+    end_date: endDate.value || undefined,
+  })
+}
 
 function formatAmount(amount: number): string {
   const formatted = formatCurrency(Math.abs(amount))
@@ -28,7 +40,10 @@ function formatAmount(amount: number): string {
         <h1 class="text-2xl font-semibold text-slate-900 dark:text-slate-100">Cash Flow Statement</h1>
         <p class="text-slate-500 dark:text-slate-400">Laporan Arus Kas - Cash movements by activity</p>
       </div>
-      <Button variant="ghost" @click="router.push('/reports')">Back to Reports</Button>
+      <div class="flex gap-2">
+        <ExportButton :show-format-options="false" :loading="exportMutation.isPending.value" @export="handleExport" />
+        <Button variant="ghost" @click="router.push('/reports')">Back to Reports</Button>
+      </div>
     </div>
 
     <!-- Date Filter -->
@@ -66,6 +81,10 @@ function formatAmount(amount: number): string {
             Year to Date
           </Button>
         </div>
+        <label class="flex items-center gap-2 text-sm text-slate-700 dark:text-slate-300 pb-1">
+          <input v-model="comparePreviousPeriod" type="checkbox" class="rounded border-slate-300" />
+          Compare previous period
+        </label>
       </div>
     </Card>
 
@@ -86,6 +105,9 @@ function formatAmount(amount: number): string {
           <h2 class="text-xl font-semibold text-slate-900 dark:text-slate-100">{{ report.report_name }}</h2>
           <p class="text-slate-500 dark:text-slate-400">
             Period: {{ report.period?.start }} to {{ report.period?.end }}
+          </p>
+          <p v-if="report.variance" class="text-sm text-slate-600 dark:text-slate-300 mt-2">
+            vs previous: net cash {{ formatAmount(report.variance.net_cash_change) }}
           </p>
         </div>
 

--- a/src/pages/reports/ChangesInEquityPage.vue
+++ b/src/pages/reports/ChangesInEquityPage.vue
@@ -1,11 +1,14 @@
 <template>
   <div class="max-w-4xl mx-auto p-6">
     <!-- Page Header -->
-    <div class="mb-6">
-      <h1 class="text-2xl font-bold text-slate-900 dark:text-slate-100">
-        Changes in Equity
-      </h1>
-      <p class="text-sm text-muted-foreground">Laporan Perubahan Ekuitas</p>
+    <div class="mb-6 flex items-center justify-between gap-4">
+      <div>
+        <h1 class="text-2xl font-bold text-slate-900 dark:text-slate-100">
+          Changes in Equity
+        </h1>
+        <p class="text-sm text-muted-foreground">Laporan Perubahan Ekuitas</p>
+      </div>
+      <ExportButton :show-format-options="false" :loading="exportMutation.isPending.value" @export="handleExport" />
     </div>
 
     <!-- Filters -->
@@ -217,8 +220,18 @@
 <script setup lang="ts">
 import { ref, computed } from 'vue'
 import { useChangesInEquity } from '@/api/useReports'
-import { Button, Input, Card } from '@/components/ui'
+import { useExportChangesInEquity } from '@/api/useExports'
+import { Button, Input, Card, ExportButton } from '@/components/ui'
 import { formatCurrency, toLocalISODate } from '@/utils/format'
+
+const exportMutation = useExportChangesInEquity()
+
+function handleExport() {
+  exportMutation.mutate({
+    start_date: startDate.value || undefined,
+    end_date: endDate.value || undefined,
+  })
+}
 
 // Date range filters - default to current month
 const startDate = ref(

--- a/src/pages/reports/DailyCashMovementPage.vue
+++ b/src/pages/reports/DailyCashMovementPage.vue
@@ -1,9 +1,12 @@
 <template>
   <div class="max-w-5xl mx-auto space-y-6">
     <!-- Header -->
-    <div>
-      <h1 class="text-3xl font-bold text-slate-900 dark:text-slate-100">Daily Cash Movement</h1>
-      <p class="text-muted-foreground">Mutasi Kas Harian</p>
+    <div class="flex items-center justify-between gap-4">
+      <div>
+        <h1 class="text-3xl font-bold text-slate-900 dark:text-slate-100">Daily Cash Movement</h1>
+        <p class="text-muted-foreground">Mutasi Kas Harian</p>
+      </div>
+      <ExportButton :show-format-options="false" :loading="exportMutation.isPending.value" @export="handleExport" />
     </div>
 
     <!-- Filter Card -->
@@ -126,7 +129,7 @@
                   {{ formatCurrency(movement.net) }}
                 </td>
                 <td class="py-3 px-4 text-right font-mono font-bold text-slate-900 dark:text-slate-100">
-                  {{ formatCurrency(movement.running_balance) }}
+                  {{ formatCurrency(movement.running_balance ?? movement.balance) }}
                 </td>
               </tr>
             </tbody>
@@ -160,7 +163,8 @@
 <script setup lang="ts">
 import { ref, computed } from 'vue'
 import { useDailyCashMovement } from '@/api/useReports'
-import { Button, Input, Card } from '@/components/ui'
+import { useExportDailyCashMovement } from '@/api/useExports'
+import { Button, Input, Card, ExportButton } from '@/components/ui'
 import { formatCurrency, formatDate, toLocalISODate } from '@/utils/format'
 
 // Date range state
@@ -173,6 +177,15 @@ const endDateRef = computed(() => endDate.value)
 
 // Fetch report data
 const { data: report, isLoading, error } = useDailyCashMovement(startDateRef, endDateRef)
+
+const exportMutation = useExportDailyCashMovement()
+
+function handleExport() {
+  exportMutation.mutate({
+    start_date: startDate.value || undefined,
+    end_date: endDate.value || undefined,
+  })
+}
 
 // Quick date range filters
 function setThisMonth() {

--- a/src/pages/reports/GeneralLedgerPage.vue
+++ b/src/pages/reports/GeneralLedgerPage.vue
@@ -3,7 +3,8 @@ import { ref, computed } from 'vue'
 import { useRouter } from 'vue-router'
 import { useGeneralLedger } from '@/api/useReports'
 import { useExportGeneralLedger } from '@/api/useExports'
-import { Button, Input, Card, ExportButton } from '@/components/ui'
+import { useJournalsLookup, journalTypeLabel } from '@/api/useJournals'
+import { Button, Input, Card, ExportButton, Select } from '@/components/ui'
 import { formatCurrency, formatDate } from '@/utils/format'
 import { ArrowLeft, ChevronDown, ChevronRight } from 'lucide-vue-next'
 
@@ -12,14 +13,30 @@ const router = useRouter()
 // Date range filters
 const startDate = ref('')
 const endDate = ref('')
+const journalId = ref('')
+const analyticAccountId = ref('')
+
+const { data: journals } = useJournalsLookup()
+const journalOptions = computed(() => {
+  const options = [{ value: '', label: 'All Journals' }]
+  if (!journals.value) return options
+  return options.concat(journals.value.map((journal) => ({
+    value: String(journal.id),
+    label: `${journal.name} (${journalTypeLabel(journal.type)})`,
+  })))
+})
 
 // Computed refs for the hook
 const startDateComputed = computed(() => startDate.value)
 const endDateComputed = computed(() => endDate.value)
+const journalIdComputed = computed(() => journalId.value || undefined)
+const analyticAccountIdComputed = computed(() => analyticAccountId.value || undefined)
 
 const { data: report, isLoading, isError, error } = useGeneralLedger(
   startDateComputed,
-  endDateComputed
+  endDateComputed,
+  journalIdComputed,
+  analyticAccountIdComputed
 )
 
 // Expanded accounts tracking
@@ -54,6 +71,8 @@ function handleExport() {
   exportMutation.mutate({
     start_date: startDate.value || undefined,
     end_date: endDate.value || undefined,
+    journal_id: journalId.value || undefined,
+    analytic_account_id: analyticAccountId.value || undefined,
   })
 }
 
@@ -116,6 +135,18 @@ function setYearToDate() {
             v-model="endDate"
             type="date"
           />
+        </div>
+        <div class="flex-1 min-w-[200px]">
+          <label class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
+            Journal
+          </label>
+          <Select v-model="journalId" :options="journalOptions" placeholder="All Journals" />
+        </div>
+        <div class="flex-1 min-w-[160px]">
+          <label class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
+            Analytic account ID
+          </label>
+          <Input v-model="analyticAccountId" type="number" min="1" placeholder="Optional" />
         </div>
         <div class="flex gap-2">
           <Button

--- a/src/pages/reports/IncomeStatementPage.vue
+++ b/src/pages/reports/IncomeStatementPage.vue
@@ -11,11 +11,13 @@ const router = useRouter()
 // Date filter state
 const startDate = ref(toLocalISODate(new Date(new Date().getFullYear(), new Date().getMonth(), 1)))
 const endDate = ref(toLocalISODate())
+const comparePreviousPeriod = ref(false)
 
 const startDateRef = computed(() => startDate.value)
 const endDateRef = computed(() => endDate.value)
+const comparePreviousPeriodRef = computed(() => comparePreviousPeriod.value)
 
-const { data: report, isLoading, error } = useIncomeStatement(startDateRef, endDateRef)
+const { data: report, isLoading, error } = useIncomeStatement(startDateRef, endDateRef, comparePreviousPeriodRef)
 
 const exportMutation = useExportIncomeStatement()
 
@@ -77,6 +79,10 @@ function formatAmount(amount: number): string {
             Year to Date
           </Button>
         </div>
+        <label class="flex items-center gap-2 text-sm text-slate-700 dark:text-slate-300 pb-1">
+          <input v-model="comparePreviousPeriod" type="checkbox" class="rounded border-slate-300" />
+          Compare previous period
+        </label>
       </div>
     </Card>
 
@@ -98,6 +104,9 @@ function formatAmount(amount: number): string {
           <h2 class="text-xl font-semibold text-slate-900 dark:text-slate-100">{{ report.report_name }}</h2>
           <p class="text-slate-500 dark:text-slate-400">
             Period: {{ report.period_start || startDate }} to {{ report.period_end || endDate }}
+          </p>
+          <p v-if="report.variance" class="text-sm text-slate-600 dark:text-slate-300 mt-2">
+            vs previous: net income {{ formatAmount(report.variance.net_income_change) }}
           </p>
         </div>
 

--- a/src/pages/reports/TrialBalancePage.vue
+++ b/src/pages/reports/TrialBalancePage.vue
@@ -3,15 +3,28 @@ import { ref, computed } from 'vue'
 import { useRouter } from 'vue-router'
 import { useTrialBalance } from '@/api/useReports'
 import { useExportTrialBalance } from '@/api/useExports'
-import { Button, Input, Card, Badge, ExportButton } from '@/components/ui'
+import { useJournalsLookup, journalTypeLabel } from '@/api/useJournals'
+import { Button, Input, Card, Badge, ExportButton, Select } from '@/components/ui'
 import { formatCurrency, toLocalISODate } from '@/utils/format'
 
 const router = useRouter()
 
 const asOfDate = ref(toLocalISODate())
+const journalId = ref('')
 const asOfDateRef = computed(() => asOfDate.value)
+const journalIdRef = computed(() => journalId.value || undefined)
 
-const { data: report, isLoading, error } = useTrialBalance(asOfDateRef)
+const { data: journals } = useJournalsLookup()
+const journalOptions = computed(() => {
+  const options = [{ value: '', label: 'All Journals' }]
+  if (!journals.value) return options
+  return options.concat(journals.value.map((journal) => ({
+    value: String(journal.id),
+    label: `${journal.name} (${journalTypeLabel(journal.type)})`,
+  })))
+})
+
+const { data: report, isLoading, error } = useTrialBalance(asOfDateRef, journalIdRef)
 
 const exportMutation = useExportTrialBalance()
 
@@ -61,6 +74,10 @@ function getAccountTypeColor(type: string): string {
         <div>
           <label class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">As of Date</label>
           <Input v-model="asOfDate" type="date" class="w-40" />
+        </div>
+        <div class="min-w-[200px]">
+          <label class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">Journal</label>
+          <Select v-model="journalId" :options="journalOptions" placeholder="All Journals" />
         </div>
         <div class="flex gap-2">
           <Button

--- a/src/pages/reports/__tests__/reportFiltersExports.test.ts
+++ b/src/pages/reports/__tests__/reportFiltersExports.test.ts
@@ -1,0 +1,32 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+function pageSource(name: string): string {
+  return readFileSync(resolve(__dirname, `../${name}`), 'utf8')
+}
+
+describe('report filters and exports (#37)', () => {
+  it.each([
+    'CashFlowPage.vue',
+    'ChangesInEquityPage.vue',
+    'DailyCashMovementPage.vue',
+  ])('shows Export on %s', (page) => {
+    const source = pageSource(page)
+    expect(source).toContain('ExportButton')
+    expect(source).toContain('handleExport')
+  })
+
+  it('filters general ledger by journal and analytic account', () => {
+    const source = pageSource('GeneralLedgerPage.vue')
+    expect(source).toContain('journalId')
+    expect(source).toContain('analyticAccountId')
+    expect(source).toContain('All Journals')
+  })
+
+  it('offers comparison on balance sheet, income statement, and cash flow', () => {
+    expect(pageSource('BalanceSheetPage.vue')).toContain('compareTo')
+    expect(pageSource('IncomeStatementPage.vue')).toContain('comparePreviousPeriod')
+    expect(pageSource('CashFlowPage.vue')).toContain('comparePreviousPeriod')
+  })
+})


### PR DESCRIPTION
## Summary
- Export CSV on Cash Flow, Changes in Equity, and Daily Cash Movement (parity with BS/P&L/GL).
- Journal filter on General Ledger and Trial Balance; analytic account ID on GL.
- Comparison: Compare-to date on Balance Sheet; Compare previous period on Income Statement and Cash Flow.

Backend: satriyop/enter365#72

Related to satriyop/enter365#37.

## Test plan
- [ ] Vitest `reportFiltersExports.test.ts`
- [ ] Cash Flow / Changes in Equity / Daily Cash Movement show Export and download CSV
- [ ] GL Journal + Analytic account ID filters the report
- [ ] BS Compare to / P&L Compare previous period show variance

## Notes
Do not merge.