### PR TITLE
feat(nav): Pembayaran and Rekonsiliasi chrome on the POS pack (#38)

### DIFF
--- a/src/config/__tests__/nav.test.ts
+++ b/src/config/__tests__/nav.test.ts
@@ -66,5 +66,24 @@ describe('navigation permission keys', () => {
     expect(posChrome('Quotations', false, POS_NAV_ID)).toBe('Quotations')
     expect(posChrome('Purchase Orders', true, POS_NAV_ID)).toBe('Pesanan Pembelian')
     expect(posChrome('Purchasing', true)).toBe('Pembelian')
+    expect(posChrome('Payments', true, POS_NAV_ID)).toBe('Pembayaran')
+    expect(posChrome('Bank Reconciliation', true, POS_NAV_ID)).toBe('Rekonsiliasi')
+  })
+
+  it('gates Payments and Bank Reconciliation on their packs', () => {
+    expect(item('Payments').feature).toBe('payments')
+    expect(item('Bank Reconciliation').feature).toBe('bank_reconciliation')
+    expect(navItemVisible(item('Payments'), {
+      featureEnabled: () => false,
+      hasPermission: () => true,
+    })).toBe(false)
+    expect(navItemVisible(item('Bank Reconciliation'), {
+      featureEnabled: (name) => name === 'bank_reconciliation',
+      hasPermission: (name) => name === 'journals.view',
+    })).toBe(true)
+    expect(navItemVisible(item('Payments'), {
+      featureEnabled: (name) => name === 'payments',
+      hasPermission: (name) => name === 'payments.view',
+    })).toBe(true)
   })
 })

--- a/src/config/nav.ts
+++ b/src/config/nav.ts
@@ -155,6 +155,7 @@ export const POS_NAV_ID: Record<string, string> = {
   'Journals': 'Jurnal (Konfigurasi)',
   'Journal Entries': 'Jurnal',
   'Fiscal Periods': 'Periode Fiskal',
+  'Bank Reconciliation': 'Rekonsiliasi',
   Payments: 'Pembayaran',
   Bills: 'Tagihan',
   Reports: 'Laporan',


### PR DESCRIPTION
## Summary
- POS chrome: **Bank Reconciliation → Rekonsiliasi** (Payments already Pembayaran).
- Nav still gated on `payments` / `bank_reconciliation` so kasir-only POS stays hidden until the parity preset (enter365#73) turns those packs on.

Backend: satriyop/enter365#73
Stacked on FE #42 (`feat/purchase-orders-pack-parity`).

Related to satriyop/enter365#38.

## Test plan
- [ ] Vitest nav.test.ts Pembayaran / Rekonsiliasi
- [ ] With payments + bank_reconciliation on: sidebar shows Pembayaran and Rekonsiliasi
- [ ] Invoice detail Pay still goes to `/payments/new?invoice_id=`

## Notes
Do not merge.