### PR TITLE
feat(products): Sales Taxes and Purchase Taxes on product form (#44)

### DIFF
--- a/src/api/useProducts.ts
+++ b/src/api/useProducts.ts
@@ -8,8 +8,14 @@ import type { components } from './types'
 // Types
 // ============================================
 
-export type Product = components['schemas']['ProductResource']
-export type CreateProductData = components['schemas']['StoreProductRequest']
+export type Product = components['schemas']['ProductResource'] & {
+  sales_taxes?: Array<{ id: number; code: string; name: string; rate: number; applicability: string }>
+  purchase_taxes?: Array<{ id: number; code: string; name: string; rate: number; applicability: string }>
+}
+export type CreateProductData = components['schemas']['StoreProductRequest'] & {
+  sales_tax_ids?: number[]
+  purchase_tax_ids?: number[]
+}
 
 export interface ProductFilters {
   page?: number

--- a/src/api/useTaxRecords.ts
+++ b/src/api/useTaxRecords.ts
@@ -1,0 +1,24 @@
+import { useQuery } from '@tanstack/vue-query'
+import { api } from './client'
+
+export interface TaxRecord {
+  id: number
+  code: string
+  name: string
+  rate: number
+  applicability: 'sales' | 'purchase' | 'both'
+  is_active: boolean
+}
+
+export function useTaxRecords(applicability?: 'sales' | 'purchase') {
+  return useQuery({
+    queryKey: ['tax-records', applicability],
+    queryFn: async () => {
+      const params: Record<string, string> = { is_active: '1', per_page: '100' }
+      if (applicability) params.applicability = applicability
+      const response = await api.get<{ data: TaxRecord[] }>('/tax-records', { params })
+      return response.data.data
+    },
+    staleTime: 5 * 60 * 1000,
+  })
+}

--- a/src/pages/products/ProductDetailPage.vue
+++ b/src/pages/products/ProductDetailPage.vue
@@ -214,6 +214,14 @@ async function handleStockAdjust() {
                 <dd class="text-foreground">{{ product.tax_rate }}%</dd>
               </div>
               <div>
+                <dt class="text-sm text-muted-foreground">Sales Taxes</dt>
+                <dd class="text-foreground">{{ product.sales_taxes?.map((tax) => `${tax.name} (${tax.rate}%)`).join(', ') || '—' }}</dd>
+              </div>
+              <div>
+                <dt class="text-sm text-muted-foreground">Purchase Taxes</dt>
+                <dd class="text-foreground">{{ product.purchase_taxes?.map((tax) => `${tax.name} (${tax.rate}%)`).join(', ') || '—' }}</dd>
+              </div>
+              <div>
                 <dt class="text-sm text-muted-foreground">Selling Price (incl. Tax)</dt>
                 <dd class="font-medium text-foreground">{{ product.selling_price_with_tax }}</dd>
               </div>

--- a/src/pages/products/ProductFormPage.vue
+++ b/src/pages/products/ProductFormPage.vue
@@ -4,6 +4,7 @@ import { useRoute, useRouter } from 'vue-router'
 import { useForm } from 'vee-validate'
 import { toTypedSchema } from '@vee-validate/zod'
 import { useProduct, useCreateProduct, useUpdateProduct, type CreateProductData } from '@/api/useProducts'
+import { useTaxRecords } from '@/api/useTaxRecords'
 import { useProductCategoriesLookup } from '@/api/useProductCategories'
 import { useAccountsLookup } from '@/api/useAccounts'
 import { toNumber } from '@/utils/format'
@@ -75,6 +76,8 @@ const {
     selling_price: 0,
     tax_rate: 11,
     is_taxable: true,
+    sales_tax_ids: [],
+    purchase_tax_ids: [],
     is_active: true,
     track_inventory: true,
     min_stock: 0,
@@ -99,6 +102,25 @@ const [purchasePrice] = defineField('purchase_price')
 const [sellingPrice] = defineField('selling_price')
 const [taxRate] = defineField('tax_rate')
 const [isTaxable] = defineField('is_taxable')
+const [salesTaxIds] = defineField('sales_tax_ids')
+const [purchaseTaxIds] = defineField('purchase_tax_ids')
+
+const { data: salesTaxRecords } = useTaxRecords('sales')
+const { data: purchaseTaxRecords } = useTaxRecords('purchase')
+
+function toggleSalesTax(id: number) {
+  const current = salesTaxIds.value ?? []
+  salesTaxIds.value = current.includes(id)
+    ? current.filter((item) => item !== id)
+    : [...current, id]
+}
+
+function togglePurchaseTax(id: number) {
+  const current = purchaseTaxIds.value ?? []
+  purchaseTaxIds.value = current.includes(id)
+    ? current.filter((item) => item !== id)
+    : [...current, id]
+}
 const [isActive] = defineField('is_active')
 const [trackInventory] = defineField('track_inventory')
 const [minStock] = defineField('min_stock')
@@ -139,6 +161,8 @@ watch(existingProduct, (product) => {
       selling_price: toNumber(product.selling_price),
       tax_rate: toNumber(product.tax_rate),
       is_taxable: !!product.is_taxable,
+      sales_tax_ids: product.sales_taxes?.map((tax) => tax.id) ?? [],
+      purchase_tax_ids: product.purchase_taxes?.map((tax) => tax.id) ?? [],
       is_active: !!product.is_active,
       track_inventory: !!product.track_inventory,
       min_stock: toNumber(product.min_stock),
@@ -176,6 +200,8 @@ const onSubmit = handleSubmit(async (formValues) => {
       selling_price: formValues.selling_price,
       tax_rate: formValues.tax_rate,
       is_taxable: formValues.is_taxable,
+      sales_tax_ids: formValues.sales_tax_ids ?? [],
+      purchase_tax_ids: formValues.purchase_tax_ids ?? [],
       is_active: formValues.is_active,
       track_inventory: formValues.track_inventory,
       min_stock: formValues.min_stock,
@@ -296,6 +322,42 @@ useFormShortcuts({
               <span class="text-sm text-foreground">Taxable</span>
             </label>
           </div>
+          <FormField label="Sales Taxes" class="md:col-span-2">
+            <div class="flex flex-wrap gap-3">
+              <label
+                v-for="tax in salesTaxRecords"
+                :key="tax.id"
+                class="flex items-center gap-2 text-sm text-foreground"
+              >
+                <input
+                  type="checkbox"
+                  class="rounded border-border"
+                  :checked="(salesTaxIds ?? []).includes(tax.id)"
+                  @change="toggleSalesTax(tax.id)"
+                />
+                {{ tax.name }} ({{ tax.rate }}%)
+              </label>
+              <p v-if="!salesTaxRecords?.length" class="text-sm text-muted-foreground">No sales tax records yet.</p>
+            </div>
+          </FormField>
+          <FormField label="Purchase Taxes" class="md:col-span-2">
+            <div class="flex flex-wrap gap-3">
+              <label
+                v-for="tax in purchaseTaxRecords"
+                :key="tax.id"
+                class="flex items-center gap-2 text-sm text-foreground"
+              >
+                <input
+                  type="checkbox"
+                  class="rounded border-border"
+                  :checked="(purchaseTaxIds ?? []).includes(tax.id)"
+                  @change="togglePurchaseTax(tax.id)"
+                />
+                {{ tax.name }} ({{ tax.rate }}%)
+              </label>
+              <p v-if="!purchaseTaxRecords?.length" class="text-sm text-muted-foreground">No purchase tax records yet.</p>
+            </div>
+          </FormField>
         </div>
       </Card>
 

--- a/src/utils/__tests__/validation.test.ts
+++ b/src/utils/__tests__/validation.test.ts
@@ -519,6 +519,22 @@ describe('nullable vs optional pattern', () => {
     }
   })
 
+  it('product accepts sales and purchase tax record ids', () => {
+    const result = productSchema.safeParse({
+      sku: 'SKU001',
+      name: 'Product',
+      type: 'product',
+      unit: 'pcs',
+      sales_tax_ids: [1],
+      purchase_tax_ids: [2],
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.sales_tax_ids).toEqual([1])
+      expect(result.data.purchase_tax_ids).toEqual([2])
+    }
+  })
+
   it('warehouse string fields default to empty string', () => {
     const result = warehouseSchema.safeParse({ name: 'Main Warehouse' })
     expect(result.success).toBe(true)

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -202,6 +202,8 @@ export const productSchema = z.object({
   selling_price: unitPriceSchema.default(0),
   tax_rate: percentageSchema.default(11),
   is_taxable: z.boolean().default(true),
+  sales_tax_ids: z.array(z.number()).optional().default([]),
+  purchase_tax_ids: z.array(z.number()).optional().default([]),
   // Inventory
   track_inventory: z.boolean().default(true),
   min_stock: z.number().min(0, 'Minimum stock cannot be negative').default(0),


### PR DESCRIPTION
## Summary
- Product Pricing card: **Sales Taxes** and **Purchase Taxes** multi-select from `/tax-records`.
- Detail page lists attached tax records.
- Flat Tax Rate (%) remains as fallback for POS.

Backend: satriyop/enter365#75

Related to satriyop/enter365#44.

## Test plan
- [ ] Vitest productSchema sales_tax_ids / purchase_tax_ids
- [ ] Create tax records, attach sales + purchase on a product, save, see them on detail

## Notes
Do not merge.