### PR TITLE
feat(products): On Hand/Forecasted, Combo type, and Routes (#46)

### DIFF
--- a/src/api/useProducts.ts
+++ b/src/api/useProducts.ts
@@ -26,8 +26,13 @@ export type Product = components['schemas']['ProductResource'] & {
   purchase_control_policy?: 'ordered' | 'received'
   purchase_description?: string | null
   vendor_pricelists?: ProductVendorPricelist[]
+  incoming_qty?: number
+  outgoing_qty?: number
+  forecasted_qty?: number
+  procurement_type?: 'buy' | 'make' | 'subcontract' | null
 }
 export type CreateProductData = components['schemas']['StoreProductRequest'] & {
+  type?: 'product' | 'service' | 'combo'
   sales_tax_ids?: number[]
   purchase_tax_ids?: number[]
   purchase_control_policy?: 'ordered' | 'received'
@@ -41,13 +46,14 @@ export type CreateProductData = components['schemas']['StoreProductRequest'] & {
     lead_time_days?: number
     vendor_product_code?: string | null
   }>
+  procurement_type?: 'buy' | 'make' | 'subcontract'
 }
 
 export interface ProductFilters {
   page?: number
   per_page?: number
   search?: string
-  type?: 'product' | 'service'
+  type?: 'product' | 'service' | 'combo'
   category_id?: number
   is_active?: boolean
 }

--- a/src/pages/products/ProductDetailPage.vue
+++ b/src/pages/products/ProductDetailPage.vue
@@ -174,6 +174,10 @@ async function handleStockAdjust() {
                 <dd class="text-foreground">{{ productTypeLabel(product, posPack) }}</dd>
               </div>
               <div>
+                <dt class="text-sm text-muted-foreground">Routes</dt>
+                <dd class="text-foreground">{{ product.procurement_type === 'make' ? 'Make' : product.procurement_type === 'subcontract' ? 'Subcontract' : 'Buy' }}</dd>
+              </div>
+              <div>
                 <dt class="text-sm text-muted-foreground">Category</dt>
                 <dd class="text-foreground">{{ product.category?.name ?? '-' }}</dd>
               </div>
@@ -321,8 +325,20 @@ async function handleStockAdjust() {
             </template>
             <dl class="space-y-3">
               <div class="flex justify-between">
-                <dt class="text-muted-foreground">Total Stock</dt>
+                <dt class="text-muted-foreground">On Hand</dt>
                 <dd class="font-medium text-foreground">{{ product.current_stock ?? 0 }} {{ product.unit }}</dd>
+              </div>
+              <div class="flex justify-between">
+                <dt class="text-muted-foreground">Incoming</dt>
+                <dd class="text-foreground">{{ product.incoming_qty ?? 0 }}</dd>
+              </div>
+              <div class="flex justify-between">
+                <dt class="text-muted-foreground">Outgoing</dt>
+                <dd class="text-foreground">{{ product.outgoing_qty ?? 0 }}</dd>
+              </div>
+              <div class="flex justify-between">
+                <dt class="text-muted-foreground">Forecasted</dt>
+                <dd class="font-medium text-foreground">{{ product.forecasted_qty ?? product.current_stock ?? 0 }}</dd>
               </div>
               <div class="flex justify-between">
                 <dt class="text-muted-foreground">Min Stock</dt>

--- a/src/pages/products/ProductFormPage.vue
+++ b/src/pages/products/ProductFormPage.vue
@@ -74,6 +74,7 @@ const {
     name: '',
     description: '',
     type: 'product',
+    procurement_type: 'buy',
     unit: 'pcs',
     purchase_price: 0,
     selling_price: 0,
@@ -103,6 +104,7 @@ const [sku] = defineField('sku')
 const [name] = defineField('name')
 const [description] = defineField('description')
 const [type] = defineField('type')
+const [procurementType] = defineField('procurement_type')
 const [unit] = defineField('unit')
 const [purchasePrice] = defineField('purchase_price')
 const [sellingPrice] = defineField('selling_price')
@@ -144,8 +146,15 @@ const [salesAccountId] = defineField('sales_account_id')
 const [purchaseAccountId] = defineField('purchase_account_id')
 
 const typeOptions = [
-  { value: 'product', label: 'Product' },
+  { value: 'product', label: 'Product (Goods)' },
   { value: 'service', label: 'Service' },
+  { value: 'combo', label: 'Combo' },
+]
+
+const routeOptions = [
+  { value: 'buy', label: 'Buy' },
+  { value: 'make', label: 'Make' },
+  { value: 'subcontract', label: 'Subcontract' },
 ]
 
 const vendorOptions = computed(() => [
@@ -198,7 +207,8 @@ watch(existingProduct, (product) => {
     setValues({
       sku: product.sku,
       name: product.name,
-      type: product.type as 'product' | 'service',
+      type: product.type as 'product' | 'service' | 'combo',
+      procurement_type: product.procurement_type ?? 'buy',
       description: product.description || '',
       unit: product.unit,
       purchase_price: toNumber(product.purchase_price),
@@ -249,6 +259,7 @@ const onSubmit = handleSubmit(async (formValues) => {
       sku: formValues.sku || null,
       name: formValues.name,
       type: formValues.type,
+      procurement_type: formValues.procurement_type,
       description: formValues.description || null,
       unit: formValues.unit,
       purchase_price: formValues.purchase_price,
@@ -342,6 +353,9 @@ useFormShortcuts({
           </FormField>
           <FormField label="Type" required :error="errors.type">
             <Select v-model="type" test-id="product-type" :options="typeOptions" @update:model-value="validateField('type')" />
+          </FormField>
+          <FormField label="Routes">
+            <Select v-model="procurementType" :options="routeOptions" />
           </FormField>
           <FormField label="Name" required :error="errors.name" class="md:col-span-2">
             <Input v-model="name" data-testid="product-name" placeholder="Product name" @blur="validateField('name')" />

--- a/src/pages/products/ProductListPage.vue
+++ b/src/pages/products/ProductListPage.vue
@@ -62,6 +62,7 @@ const typeOptions = computed(() => [
   { value: '', label: posChrome('All Types', posPack.value) },
   { value: 'product', label: posChrome('Products', posPack.value) },
   { value: 'service', label: posChrome('Services', posPack.value) },
+  { value: 'combo', label: 'Combo' },
 ])
 
 const columns = computed<ResponsiveColumn[]>(() => [
@@ -69,7 +70,8 @@ const columns = computed<ResponsiveColumn[]>(() => [
   { key: 'name', label: posChrome('Name', posPack.value), mobilePriority: 1 },
   { key: 'type', label: posChrome('Type', posPack.value), mobilePriority: 4 },
   { key: 'selling_price', label: posChrome('Price', posPack.value), align: 'right', mobilePriority: 3, format: (v) => formatCurrency(v as number) },
-  { key: 'current_stock', label: posChrome('Stock', posPack.value), align: 'right', showInMobile: false },
+  { key: 'current_stock', label: posChrome('On Hand', posPack.value) || 'On Hand', align: 'right', showInMobile: false },
+  { key: 'forecasted_qty', label: 'Forecasted', align: 'right', showInMobile: false },
 ])
 
 // Delete handling

--- a/src/utils/__tests__/validation.test.ts
+++ b/src/utils/__tests__/validation.test.ts
@@ -551,6 +551,21 @@ describe('nullable vs optional pattern', () => {
     }
   })
 
+  it('product accepts combo type and buy route', () => {
+    const result = productSchema.safeParse({
+      sku: 'KIT-1',
+      name: 'Kopi combo',
+      type: 'combo',
+      unit: 'paket',
+      procurement_type: 'buy',
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.type).toBe('combo')
+      expect(result.data.procurement_type).toBe('buy')
+    }
+  })
+
   it('product foreign key fields accept null', () => {
     const result = productSchema.safeParse({
       sku: 'SKU001',

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -198,7 +198,7 @@ export const contactSchema = z.object({
 export const productSchema = z.object({
   sku: requiredString('SKU').max(50),
   name: requiredString('Name').max(255),
-  type: z.enum(['product', 'service'], {
+  type: z.enum(['product', 'service', 'combo'], {
     errorMap: () => ({ message: 'Please select a type' }),
   }),
   description: z.string().max(500).optional().default(''),
@@ -231,6 +231,7 @@ export const productSchema = z.object({
     lead_time_days: z.number().min(0).default(0),
     vendor_product_code: z.string().max(100).optional().default(''),
   })).optional().default([]),
+  procurement_type: z.enum(['buy', 'make', 'subcontract']).optional().default('buy'),
   // Account mapping (for products with inventory tracking)
   inventory_account_id: z.number().optional().nullable(),
   cogs_account_id: z.number().optional().nullable(),


### PR DESCRIPTION
## Summary
- Product list: **On Hand** and **Forecasted** columns; Combo in type filter.
- Form: Combo type + **Routes** (Buy / Make / Subcontract).
- Detail: incoming, outgoing, forecasted beside on-hand.

Backend: satriyop/enter365#77

Related to satriyop/enter365#46.

## Test plan
- [ ] Vitest productSchema combo + procurement_type
- [ ] List shows Forecasted; create Combo; set Route to Buy

## Notes
Do not merge.