### PR TITLE
feat(inventory): counted qty grid on New Stock Opname (#47)

### DIFF
--- a/src/api/useStockOpnames.ts
+++ b/src/api/useStockOpnames.ts
@@ -24,7 +24,13 @@ export interface StockOpnameFilters {
 }
 
 // Use Scramble-generated request types directly
-export type CreateStockOpnameData = components['schemas']['StoreStockOpnameRequest']
+export type CreateStockOpnameData = components['schemas']['StoreStockOpnameRequest'] & {
+  items?: Array<{
+    product_id: number
+    counted_quantity?: number | null
+    notes?: string | null
+  }>
+}
 export type UpdateStockOpnameData = components['schemas']['UpdateStockOpnameRequest']
 
 // ============================================

--- a/src/pages/inventory/StockOpnameDetailPage.vue
+++ b/src/pages/inventory/StockOpnameDetailPage.vue
@@ -78,9 +78,10 @@ const pendingDeleteItemId = ref<number | string | null>(null)
 // Table Columns
 const columns: ResponsiveColumn[] = [
   { key: 'product.name', label: 'Product', mobilePriority: 1 },
-  { key: 'system_quantity', label: 'System Qty', align: 'right', mobilePriority: 3 },
+  { key: 'system_quantity', label: 'On Hand', align: 'right', mobilePriority: 3 },
   { key: 'actual_quantity', label: 'Counted Qty', align: 'right', mobilePriority: 2 },
-  { key: 'difference_quantity', label: 'Variance', align: 'right', showInMobile: false },
+  { key: 'difference_quantity', label: 'Difference', align: 'right', showInMobile: false },
+  { key: 'product.unit', label: 'UoM', showInMobile: false },
   { key: 'actions', label: '', showInMobile: false },
 ]
 

--- a/src/pages/inventory/StockOpnameFormPage.vue
+++ b/src/pages/inventory/StockOpnameFormPage.vue
@@ -1,21 +1,31 @@
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { useCreateStockOpname, type CreateStockOpnameData } from '@/api/useStockOpnames'
-import { useWarehousesLookup } from '@/api/useInventory'
-import { 
-  Button, 
-  Card, 
-  Input, 
-  Select, 
-  useToast 
+import { useStockLevels, useWarehousesLookup } from '@/api/useInventory'
+import { useProductsLookup } from '@/api/useProducts'
+import {
+  Button,
+  Card,
+  Input,
+  Select,
+  useToast,
 } from '@/components/ui'
-import { ArrowLeft, Save } from 'lucide-vue-next'
+import { ArrowLeft, Plus, Save, Trash2 } from 'lucide-vue-next'
+import { opnameLineDifference } from './stockOpname'
+
+interface CountLine {
+  product_id: number | null
+  book_qty: number
+  counted_qty: number | null
+  unit: string
+}
 
 const router = useRouter()
 const toast = useToast()
 
 const { data: warehouses, isLoading: isLoadingWarehouses } = useWarehousesLookup()
+const { data: products } = useProductsLookup()
 const createMutation = useCreateStockOpname()
 
 const form = ref<CreateStockOpnameData>({
@@ -25,35 +35,123 @@ const form = ref<CreateStockOpnameData>({
   notes: '',
 })
 
+const lines = ref<CountLine[]>([])
+
+const stockFilters = computed(() => ({
+  warehouse_id: form.value.warehouse_id || undefined,
+  per_page: 100,
+}))
+const { data: stockPage, refetch: refetchStock } = useStockLevels(stockFilters)
+
+const stockByProductId = computed(() => {
+  const map = new Map<number, { quantity: number; unit: string }>()
+  for (const row of stockPage.value?.data ?? []) {
+    map.set(row.product_id, {
+      quantity: Number(row.quantity ?? 0),
+      unit: row.product?.unit ?? 'pcs',
+    })
+  }
+  return map
+})
+
+const productOptions = computed(() => {
+  const chosen = new Set(lines.value.map((line) => line.product_id).filter(Boolean))
+  return (products.value ?? [])
+    .filter((product) => product.track_inventory && !chosen.has(product.id))
+    .map((product) => ({
+      value: String(product.id),
+      label: `${product.sku} - ${product.name}`,
+    }))
+})
+
+watch(warehouses, (list) => {
+  if (!list?.length || form.value.warehouse_id) {
+    return
+  }
+  const defaultWarehouse = list.find((warehouse) => warehouse.is_default) ?? list[0]
+  form.value.warehouse_id = defaultWarehouse.id
+}, { immediate: true })
+
+watch(() => form.value.warehouse_id, () => {
+  lines.value = []
+  if (form.value.warehouse_id) {
+    refetchStock()
+  }
+})
+
+function emptyLine(): CountLine {
+  return { product_id: null, book_qty: 0, counted_qty: null, unit: 'pcs' }
+}
+
+function addLine() {
+  lines.value = [...lines.value, emptyLine()]
+}
+
+function removeLine(index: number) {
+  lines.value = lines.value.filter((_, i) => i !== index)
+}
+
+function setLineProduct(index: number, value: string | number | null) {
+  const productId = value ? Number(value) : null
+  const product = products.value?.find((row) => row.id === productId)
+  const stock = productId ? stockByProductId.value.get(productId) : undefined
+  const book = stock?.quantity ?? 0
+  lines.value[index] = {
+    product_id: productId,
+    book_qty: book,
+    counted_qty: lines.value[index].counted_qty ?? book,
+    unit: stock?.unit ?? product?.unit ?? 'pcs',
+  }
+}
+
+function loadOnHandLines() {
+  const rows = stockPage.value?.data ?? []
+  if (!rows.length) {
+    toast.error('No on-hand products in this warehouse')
+    return
+  }
+  lines.value = rows.map((row) => ({
+    product_id: row.product_id,
+    book_qty: Number(row.quantity ?? 0),
+    counted_qty: Number(row.quantity ?? 0),
+    unit: row.product?.unit ?? 'pcs',
+  }))
+}
+
 async function handleSubmit() {
   if (!form.value.warehouse_id) {
     toast.error('Please select a warehouse')
     return
   }
 
+  const items = lines.value
+    .filter((line) => line.product_id)
+    .map((line) => ({
+      product_id: Number(line.product_id),
+      counted_quantity: line.counted_qty,
+    }))
+
+  if (!items.length) {
+    toast.error('Add at least one product line with counted qty')
+    return
+  }
+
   try {
-    const result = await createMutation.mutateAsync(form.value)
-    toast.success('Stock opname created successfully')
+    const result = await createMutation.mutateAsync({
+      ...form.value,
+      items,
+    })
+    toast.success('Stock opname created with count lines')
     router.push(`/inventory/opnames/${result.id}`)
-  } catch (error: any) {
-    toast.error(error.message || 'Failed to create stock opname')
+  } catch (error: unknown) {
+    const msg = (error as { message?: string })?.message
+    toast.error(msg || 'Failed to create stock opname')
   }
 }
-
-// Set default warehouse if available
-onMounted(() => {
-  if (warehouses.value?.length) {
-    const defaultWarehouse = warehouses.value.find(w => w.is_default) ?? warehouses.value[0]
-    if (defaultWarehouse) {
-      form.value.warehouse_id = defaultWarehouse.id
-    }
-  }
-})
 </script>
 
 <template>
-  <div class="max-w-2xl mx-auto space-y-6">
-    <!-- Header -->
+  <div class="max-w-5xl mx-auto space-y-6">
     <div class="flex items-center gap-4">
       <Button variant="ghost" size="sm" @click="router.back()">
         <ArrowLeft class="w-4 h-4 mr-2" />
@@ -64,54 +162,113 @@ onMounted(() => {
 
     <form novalidate @submit.prevent="handleSubmit">
       <Card class="space-y-6">
-        <!-- Warehouse Selection -->
-        <div class="space-y-2">
-          <label class="text-sm font-medium text-slate-700 dark:text-slate-300">Warehouse</label>
-          <Select
-            v-model="form.warehouse_id"
-            :options="warehouses?.map(w => ({ value: w.id, label: `${w.name} (${w.code})` })) || []"
-            :loading="isLoadingWarehouses"
-            placeholder="Select a warehouse to count"
-            required
-            testId="opname-warehouse"
-          />
-          <p class="text-xs text-slate-500">The system will snapshot stock levels for this warehouse.</p>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div class="space-y-2">
+            <label class="text-sm font-medium text-slate-700 dark:text-slate-300">Warehouse</label>
+            <Select
+              v-model="form.warehouse_id"
+              :options="warehouses?.map(w => ({ value: w.id, label: `${w.name} (${w.code})` })) || []"
+              :loading="isLoadingWarehouses"
+              placeholder="Select a warehouse to count"
+              required
+              testId="opname-warehouse"
+            />
+          </div>
+          <div class="space-y-2">
+            <label class="text-sm font-medium text-slate-700 dark:text-slate-300">Opname Date</label>
+            <Input
+              v-model="form.opname_date"
+              type="date"
+              required
+              data-testid="opname-date"
+            />
+          </div>
+          <div class="space-y-2">
+            <label class="text-sm font-medium text-slate-700 dark:text-slate-300">Reference Name (Optional)</label>
+            <Input
+              v-model="form.name"
+              placeholder="e.g. Monthly Count - January 2024"
+              data-testid="opname-name"
+            />
+          </div>
+          <div class="space-y-2 md:col-span-2">
+            <label class="text-sm font-medium text-slate-700 dark:text-slate-300">Notes</label>
+            <textarea
+              v-model="form.notes"
+              rows="2"
+              data-testid="opname-notes"
+              class="w-full px-3 py-2 border border-slate-300 dark:border-slate-600 rounded-sm bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100 placeholder-slate-400 dark:placeholder-slate-500 focus:ring-2 focus:ring-orange-500 focus:border-transparent"
+              placeholder="Additional information..."
+            ></textarea>
+          </div>
         </div>
 
-        <!-- Date -->
-        <div class="space-y-2">
-          <label class="text-sm font-medium text-slate-700 dark:text-slate-300">Opname Date</label>
-          <Input
-            v-model="form.opname_date"
-            type="date"
-            required
-            data-testid="opname-date"
-          />
+        <div class="space-y-3">
+          <div class="flex flex-wrap items-center justify-between gap-2">
+            <h2 class="text-sm font-semibold text-slate-900 dark:text-slate-100">Count lines</h2>
+            <div class="flex gap-2">
+              <Button type="button" variant="outline" size="sm" :disabled="!form.warehouse_id" @click="loadOnHandLines">
+                Load on-hand products
+              </Button>
+              <Button type="button" variant="outline" size="sm" @click="addLine">
+                <Plus class="h-4 w-4 mr-1" />
+                Add product
+              </Button>
+            </div>
+          </div>
+          <div class="overflow-x-auto">
+            <table class="w-full text-sm">
+              <thead>
+                <tr class="border-b border-border text-left text-muted-foreground">
+                  <th class="py-2 pr-2 font-medium">Product</th>
+                  <th class="py-2 pr-2 font-medium text-right">On Hand</th>
+                  <th class="py-2 pr-2 font-medium text-right">Counted</th>
+                  <th class="py-2 pr-2 font-medium text-right">Difference</th>
+                  <th class="py-2 pr-2 font-medium">UoM</th>
+                  <th class="py-2 w-10"></th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr v-for="(line, index) in lines" :key="index" class="border-b border-border">
+                  <td class="py-2 pr-2 min-w-[220px]">
+                    <Select
+                      :model-value="line.product_id ? String(line.product_id) : ''"
+                      :options="[{ value: '', label: 'Select product' }, ...productOptions]"
+                      @update:model-value="(v) => setLineProduct(index, v)"
+                    />
+                  </td>
+                  <td class="py-2 pr-2 text-right font-mono text-slate-500">
+                    {{ line.book_qty }}
+                  </td>
+                  <td class="py-2 pr-2 w-28">
+                    <Input v-model.number="line.counted_qty" type="number" min="0" data-testid="opname-counted-qty" />
+                  </td>
+                  <td
+                    class="py-2 pr-2 text-right font-mono"
+                    :class="{
+                      'text-green-600 dark:text-green-400': (opnameLineDifference(line.book_qty, line.counted_qty) ?? 0) > 0,
+                      'text-red-600 dark:text-red-400': (opnameLineDifference(line.book_qty, line.counted_qty) ?? 0) < 0,
+                    }"
+                  >
+                    {{ opnameLineDifference(line.book_qty, line.counted_qty) ?? '—' }}
+                  </td>
+                  <td class="py-2 pr-2">{{ line.unit }}</td>
+                  <td class="py-2">
+                    <Button type="button" variant="ghost" size="sm" @click="removeLine(index)">
+                      <Trash2 class="h-4 w-4" />
+                    </Button>
+                  </td>
+                </tr>
+                <tr v-if="!lines.length">
+                  <td colspan="6" class="py-4 text-muted-foreground">
+                    Add products and enter counted qty. On Hand is the book quantity for this warehouse.
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
         </div>
 
-        <!-- Reference Name -->
-        <div class="space-y-2">
-          <label class="text-sm font-medium text-slate-700 dark:text-slate-300">Reference Name (Optional)</label>
-          <Input
-            v-model="form.name"
-            placeholder="e.g. Monthly Count - January 2024"
-            data-testid="opname-name"
-          />
-        </div>
-
-        <!-- Notes -->
-        <div class="space-y-2">
-          <label class="text-sm font-medium text-slate-700 dark:text-slate-300">Notes</label>
-          <textarea
-            v-model="form.notes"
-            rows="3"
-            data-testid="opname-notes"
-            class="w-full px-3 py-2 border border-slate-300 dark:border-slate-600 rounded-sm bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100 placeholder-slate-400 dark:placeholder-slate-500 focus:ring-2 focus:ring-orange-500 focus:border-transparent"
-            placeholder="Additional information..."
-          ></textarea>
-        </div>
-
-        <!-- Footer Actions -->
         <template #footer>
           <div class="flex justify-end gap-3">
             <Button variant="ghost" type="button" @click="router.back()">Cancel</Button>
@@ -121,7 +278,7 @@ onMounted(() => {
               data-testid="opname-submit"
             >
               <Save class="w-4 h-4 mr-2" />
-              Create & Continue
+              Create Opname
             </Button>
           </div>
         </template>

--- a/src/pages/inventory/StockOpnameListPage.vue
+++ b/src/pages/inventory/StockOpnameListPage.vue
@@ -21,6 +21,7 @@ import {
 } from '@/components/ui'
 import { Plus, Search, Package } from 'lucide-vue-next'
 import { ref } from 'vue'
+import { opnameListStatusLabel } from './stockOpname'
 
 const toast = useToast()
 const showDeleteModal = ref(false)
@@ -54,9 +55,9 @@ const deleteMutation = useDeleteStockOpname()
 const statusOptions = [
   { value: '', label: 'All Status' },
   { value: 'draft', label: 'Draft' },
-  { value: 'counting', label: 'Counting' },
+  { value: 'counting', label: 'In Progress' },
   { value: 'reviewed', label: 'Reviewed' },
-  { value: 'completed', label: 'Completed' },
+  { value: 'completed', label: 'Done' },
   { value: 'cancelled', label: 'Cancelled' },
 ]
 
@@ -187,7 +188,7 @@ async function confirmDelete() {
           <!-- Custom cell: Status -->
           <template #cell-status="{ item }">
             <Badge :status="item.status.value as any">
-              {{ item.status.label }}
+              {{ opnameListStatusLabel(item.status.value, item.status.label) }}
             </Badge>
           </template>
 

--- a/src/pages/inventory/__tests__/stockOpname.test.ts
+++ b/src/pages/inventory/__tests__/stockOpname.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+import { opnameLineDifference, opnameListStatusLabel } from '../stockOpname'
+
+describe('stock opname count lines', () => {
+  it('computes counted minus book qty', () => {
+    expect(opnameLineDifference(100, 95)).toBe(-5)
+    expect(opnameLineDifference(40, 40)).toBe(0)
+    expect(opnameLineDifference(0, 3)).toBe(3)
+    expect(opnameLineDifference(10, null)).toBeNull()
+  })
+
+  it('maps list statuses to Draft / In Progress / Done', () => {
+    expect(opnameListStatusLabel('draft')).toBe('Draft')
+    expect(opnameListStatusLabel('counting')).toBe('In Progress')
+    expect(opnameListStatusLabel('completed')).toBe('Done')
+    expect(opnameListStatusLabel('reviewed', 'Reviewed')).toBe('Reviewed')
+  })
+})

--- a/src/pages/inventory/stockOpname.ts
+++ b/src/pages/inventory/stockOpname.ts
@@ -1,0 +1,24 @@
+export function opnameLineDifference(
+  bookQty: number,
+  countedQty: number | null | undefined,
+): number | null {
+  if (countedQty === null || countedQty === undefined || Number.isNaN(Number(countedQty))) {
+    return null
+  }
+
+  return Number(countedQty) - bookQty
+}
+
+export function opnameListStatusLabel(value: string, fallback?: string): string {
+  if (value === 'draft') {
+    return 'Draft'
+  }
+  if (value === 'counting') {
+    return 'In Progress'
+  }
+  if (value === 'completed') {
+    return 'Done'
+  }
+
+  return fallback ?? value
+}


### PR DESCRIPTION
## Summary
- New Opname form: product lines with **On Hand** (book), **Counted**, **Difference**, **UoM**.
- Load on-hand products from the warehouse, or add lines one by one.
- List statuses: Draft / In Progress / Done (counting / completed).
- Detail table: On Hand, Counted, Difference, UoM.

Backend: satriyop/enter365#78

Related to satriyop/enter365#47.

## Test plan
- [ ] Vitest `stockOpname.test.ts` difference + status labels
- [ ] New Opname: add a line, counted ≠ on hand, create, see the line on detail

## Notes
Do not merge.