### PR TITLE
feat(inventory): On Hand, Free to Use, Incoming, Outgoing on Stok (#49)

### DIFF
--- a/src/api/useInventory.ts
+++ b/src/api/useInventory.ts
@@ -9,7 +9,12 @@ import type { components } from './types'
 // ─────────────────────────────────────────────────────────────
 
 export type InventoryMovement = components['schemas']['InventoryMovementResource']
-export type ProductStock = components['schemas']['ProductStockResource']
+export type ProductStock = components['schemas']['ProductStockResource'] & {
+  reserved_quantity?: number
+  free_to_use?: number
+  incoming_qty?: number
+  outgoing_qty?: number
+}
 export type Warehouse = components['schemas']['WarehouseResource']
 
 export interface StockCardResponse {

--- a/src/pages/inventory/InventoryListPage.vue
+++ b/src/pages/inventory/InventoryListPage.vue
@@ -5,6 +5,7 @@ import { computed } from 'vue'
 import { Button, Input, Pagination, EmptyState, Badge, ResponsiveTable, type ResponsiveColumn } from '@/components/ui'
 import { formatCurrency } from '@/utils/format'
 import { POS_NAV_ID, posChrome } from '@/config/nav'
+import { freeToUse } from './stockPipeline'
 import { useFeaturesStore } from '@/stores/features'
 
 const features = useFeaturesStore()
@@ -39,7 +40,10 @@ const columns = computed<ResponsiveColumn[]>(() => [
   { key: 'product.sku', label: 'SKU', mobilePriority: 3 },
   { key: 'product.name', label: posChrome('Product', posPack.value), mobilePriority: 1 },
   { key: 'warehouse.name', label: posChrome('Warehouse', posPack.value), showInMobile: false },
-  { key: 'quantity', label: posChrome('Quantity', posPack.value), align: 'right', mobilePriority: 2 },
+  { key: 'quantity', label: posChrome('On Hand', posPack.value) || 'On Hand', align: 'right', mobilePriority: 2 },
+  { key: 'free_to_use', label: 'Free to Use', align: 'right', showInMobile: false },
+  { key: 'incoming_qty', label: 'Incoming', align: 'right', showInMobile: false },
+  { key: 'outgoing_qty', label: 'Outgoing', align: 'right', showInMobile: false },
   { key: 'average_cost', label: posChrome('Avg Cost', posPack.value), align: 'right', showInMobile: false },
   { key: 'total_value', label: posChrome('Value', posPack.value), align: 'right', mobilePriority: 4 },
   { key: 'level', label: posChrome('Level', posPack.value), showInMobile: false },
@@ -125,6 +129,15 @@ const columns = computed<ResponsiveColumn[]>(() => [
         <!-- Custom cell: Quantity -->
         <template #cell-quantity="{ item }">
           <span class="block text-right tabular-nums">{{ item.quantity }} {{ item.product?.unit }}</span>
+        </template>
+        <template #cell-free_to_use="{ item }">
+          <span class="block text-right tabular-nums">{{ item.free_to_use ?? freeToUse(Number(item.quantity), Number(item.reserved_quantity ?? 0)) }}</span>
+        </template>
+        <template #cell-incoming_qty="{ item }">
+          <span class="block text-right tabular-nums">{{ item.incoming_qty ?? 0 }}</span>
+        </template>
+        <template #cell-outgoing_qty="{ item }">
+          <span class="block text-right tabular-nums">{{ item.outgoing_qty ?? 0 }}</span>
         </template>
 
         <template #cell-average_cost="{ item }">

--- a/src/pages/inventory/__tests__/stockPipeline.test.ts
+++ b/src/pages/inventory/__tests__/stockPipeline.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest'
+import { freeToUse } from '../stockPipeline'
+
+describe('stock list pipeline qty', () => {
+  it('free to use is on hand minus reserved', () => {
+    expect(freeToUse(10, 3)).toBe(7)
+    expect(freeToUse(2, 5)).toBe(0)
+  })
+})

--- a/src/pages/inventory/stockPipeline.ts
+++ b/src/pages/inventory/stockPipeline.ts
@@ -1,0 +1,3 @@
+export function freeToUse(onHand: number, reserved: number): number {
+  return Math.max(0, onHand - reserved)
+}


### PR DESCRIPTION
## Summary
- Stok list columns: **On Hand**, **Free to Use**, **Incoming**, **Outgoing**.

Backend: satriyop/enter365#81
Stacked on FE #52 (`feat/product-forecast-combo-routes`).

Related to satriyop/enter365#49.

## Test plan
- [ ] Vitest freeToUse
- [ ] Stok page shows the four qty columns

## Notes
Do not merge.