### PR TITLE
feat(accounting): analytic account master + JE picker (#57)

### DIFF
--- a/src/api/__tests__/analytic-accounts.test.ts
+++ b/src/api/__tests__/analytic-accounts.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import {
+  analyticDistributionFromAccountId,
+  analyticDistributionPrimaryId,
+  formatAnalyticDistributionLabel,
+} from '../useAnalyticAccounts'
+
+describe('analytic account picker helpers', () => {
+  it('maps a selected analytic account to a 100% distribution', () => {
+    expect(analyticDistributionFromAccountId('7')).toEqual({ '7': 100 })
+    expect(analyticDistributionFromAccountId(12)).toEqual({ '12': 100 })
+    expect(analyticDistributionFromAccountId('')).toBeNull()
+    expect(analyticDistributionFromAccountId(null)).toBeNull()
+  })
+
+  it('reads the primary analytic account id from a distribution map', () => {
+    expect(analyticDistributionPrimaryId({ '7': 100 })).toBe('7')
+    expect(analyticDistributionPrimaryId({ '3': 60, '4': 40 })).toBe('3')
+    expect(analyticDistributionPrimaryId(null)).toBe('')
+  })
+
+  it('labels distribution using analytic account master rows', () => {
+    const accounts = [
+      { id: 7, code: 'MKT', name: 'Marketing', is_active: true },
+      { id: 8, code: 'OPS', name: 'Operations', is_active: true },
+    ]
+    expect(formatAnalyticDistributionLabel({ '7': 100 }, accounts)).toBe('MKT Marketing 100%')
+    expect(formatAnalyticDistributionLabel({ '7': 60, '8': 40 }, accounts)).toBe(
+      'MKT Marketing 60%, OPS Operations 40%',
+    )
+    expect(formatAnalyticDistributionLabel({ '99': 100 }, accounts)).toBe('99 100%')
+    expect(formatAnalyticDistributionLabel(null, accounts)).toBe('')
+  })
+})

--- a/src/api/useAnalyticAccounts.ts
+++ b/src/api/useAnalyticAccounts.ts
@@ -1,0 +1,76 @@
+import { createCrudHooks } from './factory'
+
+export interface AnalyticAccount {
+  id: number
+  code: string
+  name: string
+  is_active: boolean
+}
+
+export interface AnalyticAccountFilters {
+  page?: number
+  per_page?: number
+  search?: string
+  is_active?: boolean
+}
+
+export interface CreateAnalyticAccountData {
+  code: string
+  name: string
+  is_active?: boolean
+}
+
+export type UpdateAnalyticAccountData = Partial<CreateAnalyticAccountData>
+
+const hooks = createCrudHooks<
+  AnalyticAccount,
+  AnalyticAccountFilters,
+  CreateAnalyticAccountData,
+  UpdateAnalyticAccountData
+>({
+  resourceName: 'analytic-accounts',
+  singularName: 'analytic-account',
+  lookupParams: { is_active: true, per_page: 200 },
+})
+
+export const useAnalyticAccounts = hooks.useList
+export const useAnalyticAccount = hooks.useSingle
+export const useCreateAnalyticAccount = hooks.useCreate
+export const useUpdateAnalyticAccount = hooks.useUpdate
+export const useAnalyticAccountsLookup = hooks.useLookup
+
+export function analyticDistributionFromAccountId(
+  id: string | number | null | undefined,
+): { [key: string]: number } | null {
+  if (id === null || id === undefined || id === '') {
+    return null
+  }
+  return { [String(id)]: 100 }
+}
+
+export function analyticDistributionPrimaryId(
+  value: { [key: string]: number } | null | undefined,
+): string {
+  if (!value) {
+    return ''
+  }
+  const keys = Object.keys(value)
+  return keys[0] ?? ''
+}
+
+export function formatAnalyticDistributionLabel(
+  value: { [key: string]: number } | null | undefined,
+  accounts: AnalyticAccount[] | undefined,
+): string {
+  if (!value || Object.keys(value).length === 0) {
+    return ''
+  }
+
+  return Object.entries(value)
+    .map(([id, pct]) => {
+      const account = accounts?.find((row) => String(row.id) === String(id))
+      const label = account ? `${account.code} ${account.name}` : id
+      return `${label} ${pct}%`
+    })
+    .join(', ')
+}

--- a/src/config/nav.ts
+++ b/src/config/nav.ts
@@ -74,6 +74,7 @@ export const navigation: NavGroup[] = [
     items: [
       { name: 'Chart of Accounts', path: '/accounting/accounts', icon: '📒', permission: 'accounts.view' },
       { name: 'Journals', path: '/accounting/journals', icon: '🗂️', permission: 'journals.view' },
+      { name: 'Analytic Accounts', path: '/accounting/analytic-accounts', icon: '🎯', permission: 'journals.view' },
       { name: 'Journal Entries', path: '/accounting/journal-entries', icon: '📝', permission: 'journals.view' },
       { name: 'Fiscal Periods', path: '/accounting/fiscal-periods', icon: '📅', permission: 'fiscal_periods.view' },
       { name: 'Budgets', path: '/accounting/budgets', icon: '📊', permission: 'budgets.view', feature: 'budgeting' },

--- a/src/pages/accounting/analytic-accounts/AnalyticAccountFormPage.vue
+++ b/src/pages/accounting/analytic-accounts/AnalyticAccountFormPage.vue
@@ -1,0 +1,133 @@
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import {
+  useAnalyticAccount,
+  useCreateAnalyticAccount,
+  useUpdateAnalyticAccount,
+} from '@/api/useAnalyticAccounts'
+import { Button, Card, Input, Select, useToast } from '@/components/ui'
+import { ArrowLeft, Save, Loader2 } from 'lucide-vue-next'
+
+const route = useRoute()
+const router = useRouter()
+const toast = useToast()
+
+const accountId = computed(() => (route.params.id ? String(route.params.id) : null))
+const isEditing = computed(() => !!accountId.value)
+const pageTitle = computed(() => (isEditing.value ? 'Edit Analytic Account' : 'New Analytic Account'))
+
+const { data: existing, isLoading: loadingAccount } = useAnalyticAccount(
+  computed(() => accountId.value ?? ''),
+)
+
+const code = ref('')
+const name = ref('')
+const isActive = ref(true)
+
+watch(existing, (account) => {
+  if (!account) return
+  code.value = account.code
+  name.value = account.name
+  isActive.value = account.is_active
+}, { immediate: true })
+
+const createMutation = useCreateAnalyticAccount()
+const updateMutation = useUpdateAnalyticAccount()
+const isSubmitting = computed(() => createMutation.isPending.value || updateMutation.isPending.value)
+
+const statusOptions = [
+  { value: '1', label: 'Active' },
+  { value: '0', label: 'Inactive' },
+]
+
+async function handleSubmit() {
+  if (!code.value.trim()) {
+    toast.error('Code is required')
+    return
+  }
+  if (!name.value.trim()) {
+    toast.error('Name is required')
+    return
+  }
+
+  const payload = {
+    code: code.value.trim(),
+    name: name.value.trim(),
+    is_active: isActive.value,
+  }
+
+  try {
+    if (isEditing.value && accountId.value) {
+      await updateMutation.mutateAsync({ id: accountId.value, data: payload })
+      toast.success('Analytic account updated')
+    } else {
+      await createMutation.mutateAsync(payload)
+      toast.success('Analytic account created')
+    }
+    router.push('/accounting/analytic-accounts')
+  } catch {
+    toast.error(isEditing.value ? 'Failed to update analytic account' : 'Failed to create analytic account')
+  }
+}
+</script>
+
+<template>
+  <div>
+    <div class="flex items-center gap-2 text-sm text-slate-500 dark:text-slate-400 mb-4">
+      <RouterLink to="/accounting/analytic-accounts" class="hover:text-slate-700 dark:hover:text-slate-300 flex items-center gap-1">
+        <ArrowLeft class="w-4 h-4" />
+        Analytic Accounts
+      </RouterLink>
+      <span>/</span>
+      <span class="text-slate-900 dark:text-slate-100">{{ pageTitle }}</span>
+    </div>
+
+    <div class="mb-6">
+      <h1 class="text-2xl font-semibold text-slate-900 dark:text-slate-100">{{ pageTitle }}</h1>
+      <p class="text-slate-500 dark:text-slate-400">Used as the journal entry Analytic Distribution picker</p>
+    </div>
+
+    <div v-if="isEditing && loadingAccount" class="py-12 text-center text-slate-500">
+      <Loader2 class="w-5 h-5 animate-spin inline mr-2" />
+      Loading...
+    </div>
+
+    <form v-else @submit.prevent="handleSubmit">
+      <Card class="mb-6 max-w-2xl">
+        <div class="space-y-4">
+          <div>
+            <label class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
+              Code <span class="text-red-500">*</span>
+            </label>
+            <Input v-model="code" data-testid="analytic-account-code" placeholder="e.g. MKT" />
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
+              Name <span class="text-red-500">*</span>
+            </label>
+            <Input v-model="name" data-testid="analytic-account-name" placeholder="e.g. Marketing" />
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">Status</label>
+            <Select
+              :model-value="isActive ? '1' : '0'"
+              :options="statusOptions"
+              :test-id="'analytic-account-active'"
+              @update:model-value="(v) => isActive = String(v) === '1'"
+            />
+          </div>
+        </div>
+      </Card>
+
+      <div class="flex items-center gap-3">
+        <Button type="submit" data-testid="analytic-account-submit" :disabled="isSubmitting">
+          <Loader2 v-if="isSubmitting" class="w-4 h-4 mr-2 animate-spin" />
+          <Save v-else class="w-4 h-4 mr-2" />
+          {{ isEditing ? 'Save' : 'Create' }}
+        </Button>
+        <Button type="button" variant="ghost" @click="router.push('/accounting/analytic-accounts')">Cancel</Button>
+      </div>
+    </form>
+  </div>
+</template>

--- a/src/pages/accounting/analytic-accounts/AnalyticAccountListPage.vue
+++ b/src/pages/accounting/analytic-accounts/AnalyticAccountListPage.vue
@@ -1,0 +1,116 @@
+<script setup lang="ts">
+import { useRouter } from 'vue-router'
+import {
+  useAnalyticAccounts,
+  type AnalyticAccount,
+  type AnalyticAccountFilters,
+} from '@/api/useAnalyticAccounts'
+import { useResourceList } from '@/composables/useResourceList'
+import { Button, Input, Card, Pagination, ResponsiveTable, type ResponsiveColumn } from '@/components/ui'
+import { Plus, Search } from 'lucide-vue-next'
+
+const router = useRouter()
+
+const {
+  items: accounts,
+  pagination,
+  isLoading,
+  error,
+  isEmpty,
+  filters,
+  updateFilter,
+  goToPage,
+} = useResourceList<AnalyticAccount, AnalyticAccountFilters>({
+  useListHook: useAnalyticAccounts,
+  initialFilters: {
+    page: 1,
+    per_page: 50,
+    search: '',
+  },
+})
+
+const columns: ResponsiveColumn[] = [
+  { key: 'code', label: 'Code', mobilePriority: 1 },
+  { key: 'name', label: 'Name', mobilePriority: 2 },
+  { key: 'is_active', label: 'Status', mobilePriority: 3 },
+]
+
+function editAccount(account: AnalyticAccount) {
+  router.push(`/accounting/analytic-accounts/${account.id}/edit`)
+}
+</script>
+
+<template>
+  <div>
+    <div class="flex items-center justify-between mb-6">
+      <div>
+        <h1 class="text-2xl font-semibold text-slate-900 dark:text-slate-100">Analytic Accounts</h1>
+        <p class="text-slate-500 dark:text-slate-400">
+          Master for journal entry analytic distribution
+        </p>
+      </div>
+      <Button data-testid="analytic-account-create" @click="router.push('/accounting/analytic-accounts/new')">
+        <Plus class="w-4 h-4 mr-1" />
+        New Analytic Account
+      </Button>
+    </div>
+
+    <Card class="mb-4">
+      <div class="flex flex-col sm:flex-row gap-3 p-4">
+        <div class="relative flex-1">
+          <Search class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400" />
+          <Input
+            :model-value="filters.search ?? ''"
+            class="pl-9"
+            placeholder="Search code or name..."
+            data-testid="analytic-account-search"
+            @update:model-value="(v) => updateFilter('search', String(v))"
+          />
+        </div>
+      </div>
+    </Card>
+
+    <Card>
+      <div v-if="error" class="py-12 text-center text-red-500">Failed to load analytic accounts</div>
+      <div v-else-if="isEmpty && !isLoading" class="py-12 text-center text-slate-500">No analytic accounts found</div>
+      <ResponsiveTable
+        v-else
+        :items="accounts ?? []"
+        :columns="columns"
+        :loading="isLoading"
+        empty-message="No analytic accounts found"
+        @row-click="editAccount"
+      >
+        <template #cell-code="{ item }">
+          <code class="text-sm">{{ item.code }}</code>
+        </template>
+        <template #cell-name="{ item }">
+          <span class="font-medium text-slate-900 dark:text-slate-100">{{ item.name }}</span>
+        </template>
+        <template #cell-is_active="{ item }">
+          <span
+            class="inline-flex px-2 py-0.5 rounded text-xs"
+            :class="item.is_active
+              ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
+              : 'bg-slate-100 text-slate-600 dark:bg-slate-700 dark:text-slate-400'"
+          >
+            {{ item.is_active ? 'Active' : 'Inactive' }}
+          </span>
+        </template>
+        <template #actions="{ item }">
+          <Button variant="ghost" size="xs" @click.stop="editAccount(item)">Edit</Button>
+        </template>
+      </ResponsiveTable>
+
+      <div v-if="pagination" class="px-6 py-4 border-t border-slate-200 dark:border-slate-700">
+        <Pagination
+          :current-page="pagination.current_page"
+          :total-pages="pagination.last_page"
+          :total="pagination.total"
+          :per-page="pagination.per_page"
+          @page-change="goToPage"
+        />
+      </div>
+    </Card>
+  </div>
+</template>

--- a/src/pages/accounting/journal-entries/JournalEntryDetailPage.vue
+++ b/src/pages/accounting/journal-entries/JournalEntryDetailPage.vue
@@ -7,9 +7,12 @@ import {
   usePostJournalEntry,
   useReverseJournalEntry,
   getJournalEntryStatus,
-  formatAnalyticDistribution,
   formatTaxTagIds,
 } from '@/api/useJournalEntries'
+import {
+  formatAnalyticDistributionLabel,
+  useAnalyticAccountsLookup,
+} from '@/api/useAnalyticAccounts'
 import { formatCurrency, formatDate } from '@/utils/format'
 import { Button, Card, Modal, Input, useToast } from '@/components/ui'
 import { ArrowLeft, Trash2, CheckCircle, RotateCcw, AlertTriangle } from 'lucide-vue-next'
@@ -22,6 +25,7 @@ const entryId = computed(() => String(route.params.id))
 
 // Fetch journal entry
 const { data: entry, isLoading, error, refetch } = useJournalEntry(entryId)
+const { data: analyticAccounts } = useAnalyticAccountsLookup()
 
 // Mutations
 const deleteMutation = useDeleteJournalEntry()
@@ -284,7 +288,7 @@ function viewAccount(accountId: string) {
                   <template v-else>-</template>
                 </td>
                 <td class="px-4 py-3 font-mono text-slate-600 dark:text-slate-400" data-testid="je-line-analytic">
-                  {{ formatAnalyticDistribution(line.analytic_distribution) || '-' }}
+                  {{ formatAnalyticDistributionLabel(line.analytic_distribution, analyticAccounts) || '-' }}
                 </td>
                 <td class="px-4 py-3 font-mono text-slate-600 dark:text-slate-400" data-testid="je-line-tax-grids">
                   {{ formatTaxTagIds(line.tax_tag_ids) || '-' }}

--- a/src/pages/accounting/journal-entries/JournalEntryFormPage.vue
+++ b/src/pages/accounting/journal-entries/JournalEntryFormPage.vue
@@ -6,14 +6,17 @@ import {
   calculateLineTotals,
   validateJournalLines,
   createEmptyLine,
-  formatAnalyticDistribution,
-  parseAnalyticDistribution,
   formatTaxTagIds,
   parseTaxTagIds,
   type CreateJournalEntryData,
   type CreateJournalEntryLineData,
 } from '@/api/useJournalEntries'
 import { useAccountsLookup } from '@/api/useAccounts'
+import {
+  analyticDistributionFromAccountId,
+  analyticDistributionPrimaryId,
+  useAnalyticAccountsLookup,
+} from '@/api/useAnalyticAccounts'
 import { useContactsLookup } from '@/api/useContacts'
 import { useJournalsLookup, journalTypeLabel } from '@/api/useJournals'
 import { formatCurrency } from '@/utils/format'
@@ -27,6 +30,7 @@ const toast = useToast()
 const { data: accounts, isLoading: accountsLoading } = useAccountsLookup()
 const { data: journals, isLoading: journalsLoading } = useJournalsLookup()
 const { data: contacts, isLoading: contactsLoading } = useContactsLookup()
+const { data: analyticAccounts, isLoading: analyticAccountsLoading } = useAnalyticAccountsLookup()
 const journalId = ref<string>('')
 
 
@@ -55,6 +59,14 @@ const partnerOptions = computed(() => {
   }))
 })
 
+const analyticOptions = computed(() => {
+  if (!analyticAccounts.value) return []
+  return analyticAccounts.value.map((account) => ({
+    value: String(account.id),
+    label: `${account.code} - ${account.name}`,
+  }))
+})
+
 // Form state
 const entryDate = ref(new Date().toISOString().split('T')[0])
 const description = ref('')
@@ -64,8 +76,7 @@ const lines = ref<CreateJournalEntryLineData[]>([
   createEmptyLine(),
 ])
 
-/** Draft strings for optional Odoo dimensions (no analytic/tax-tag masters yet). */
-const analyticDrafts = ref<string[]>(['', ''])
+/** Draft strings for optional tax grids (no tax-tag master yet). */
 const taxTagDrafts = ref<string[]>(['', ''])
 
 // Calculate totals
@@ -83,7 +94,6 @@ const hasErrors = computed(() => validationErrors.value.length > 0)
 // Add new line
 function addLine() {
   lines.value.push(createEmptyLine())
-  analyticDrafts.value.push('')
   taxTagDrafts.value.push('')
 }
 
@@ -91,21 +101,14 @@ function addLine() {
 function removeLine(index: number) {
   if (lines.value.length > 2) {
     lines.value.splice(index, 1)
-    analyticDrafts.value.splice(index, 1)
     taxTagDrafts.value.splice(index, 1)
   }
 }
 
-function onAnalyticInput(index: number, value: string) {
-  analyticDrafts.value[index] = value
+function onAnalyticSelect(index: number, value: string | number | null) {
   const line = lines.value[index]
   if (!line) return
-  if (!value.trim()) {
-    line.analytic_distribution = null
-    return
-  }
-  const parsed = parseAnalyticDistribution(value)
-  if (parsed) line.analytic_distribution = parsed
+  line.analytic_distribution = analyticDistributionFromAccountId(value)
 }
 
 function onTaxTagsInput(index: number, value: string) {
@@ -197,17 +200,6 @@ async function handleSubmit() {
   for (let i = 0; i < lines.value.length; i++) {
     const line = lines.value[i]
     if (!line) continue
-    const analyticRaw = analyticDrafts.value[i] ?? ''
-    if (analyticRaw.trim()) {
-      const parsed = parseAnalyticDistribution(analyticRaw)
-      if (!parsed) {
-        toast.error(`Line ${i + 1}: Analytic Distribution must be id:pct pairs (e.g. 1:100 or 1:50, 2:50)`)
-        return
-      }
-      line.analytic_distribution = parsed
-    } else {
-      line.analytic_distribution = null
-    }
     const taxRaw = taxTagDrafts.value[i] ?? ''
     if (taxRaw.trim()) {
       const parsed = parseTaxTagIds(taxRaw)
@@ -341,7 +333,7 @@ async function handleSubmit() {
                 <th class="px-4 py-3 text-left font-medium text-slate-500 dark:text-slate-400 min-w-[9rem]">
                   Partner
                 </th>
-                <th class="px-4 py-3 text-left font-medium text-slate-500 dark:text-slate-400 min-w-[8rem]" title="Odoo analytic_distribution — id:pct (no analytic master yet)">
+                <th class="px-4 py-3 text-left font-medium text-slate-500 dark:text-slate-400 min-w-[10rem]" title="Analytic account from master — stored as {id: 100}">
                   Analytic
                 </th>
                 <th class="px-4 py-3 text-left font-medium text-slate-500 dark:text-slate-400 min-w-[7rem]" title="Odoo Tax Grids / tax_tag_ids (no tax-tag master yet)">
@@ -387,12 +379,13 @@ async function handleSubmit() {
 
                 <!-- Analytic Distribution -->
                 <td class="px-4 py-2">
-                  <Input
-                    :model-value="analyticDrafts[index] ?? formatAnalyticDistribution(line.analytic_distribution)"
-                    :data-testid="`je-line-${index}-analytic`"
-                    placeholder="1:100"
-                    class="text-sm font-mono"
-                    @update:model-value="(v) => onAnalyticInput(index, String(v))"
+                  <Select
+                    :test-id="`je-line-${index}-analytic`"
+                    :model-value="analyticDistributionPrimaryId(line.analytic_distribution)"
+                    :options="analyticOptions"
+                    :loading="analyticAccountsLoading"
+                    placeholder="Optional"
+                    @update:model-value="(v) => onAnalyticSelect(index, v)"
                   />
                 </td>
 
@@ -522,7 +515,7 @@ async function handleSubmit() {
       </template>
       <ul class="text-sm text-slate-600 dark:text-slate-400 space-y-2">
         <li>• Partner (customer/vendor) is optional on each line for AR/AP reporting</li>
-        <li>• Analytic: optional id:pct pairs (e.g. 1:100) — stored as Odoo analytic_distribution JSON until an analytic master exists</li>
+        <li>• Analytic: pick an analytic account; stored as Odoo analytic_distribution JSON ({id: 100})</li>
         <li>• Tax Grids: optional comma-separated tag ids — stored as tax_tag_ids; VAT reports remain document-level for now</li>
         <li>• Each line can only have a debit OR credit amount, not both</li>
         <li>• Total debits must equal total credits for a balanced entry</li>

--- a/src/router/__tests__/access.test.ts
+++ b/src/router/__tests__/access.test.ts
@@ -9,6 +9,8 @@ describe('route permission gates', () => {
     expect(canOpenPath('/inventory/opnames/new', has)).toBe(false)
     expect(canOpenPath('/inventory/adjust', has)).toBe(false)
     expect(canOpenPath('/accounting/journal-entries', has)).toBe(true)
+    expect(canOpenPath('/accounting/analytic-accounts', has)).toBe(true)
+    expect(canOpenPath('/accounting/analytic-accounts/new', has)).toBe(false)
     expect(canOpenPath('/reports/trial-balance', has)).toBe(true)
     expect(canOpenPath('/reports/stock-summary', has)).toBe(false)
   })

--- a/src/router/access.ts
+++ b/src/router/access.ts
@@ -5,6 +5,8 @@ export const PERMISSION_ROUTE_PREFIXES: Array<{ prefix: string; permission: stri
   { prefix: '/inventory/transfer', permission: 'inventory.transfer' },
   { prefix: '/accounting/journals/new', permission: 'journals.create' },
   { prefix: '/accounting/journals', permission: 'journals.view' },
+  { prefix: '/accounting/analytic-accounts/new', permission: 'journals.create' },
+  { prefix: '/accounting/analytic-accounts', permission: 'journals.view' },
   { prefix: '/accounting/journal-entries/new', permission: 'journals.create' },
   { prefix: '/accounting/journal-entries', permission: 'journals.view' },
   { prefix: '/reports/stock-summary', permission: 'inventory.view' },

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -534,6 +534,24 @@ const router = createRouter({
           component: () => import('@/pages/accounting/journals/JournalFormPage.vue'),
           meta: { breadcrumb: 'Edit Journal' }
         },
+        {
+          path: 'accounting/analytic-accounts',
+          name: 'analytic-accounts',
+          component: () => import('@/pages/accounting/analytic-accounts/AnalyticAccountListPage.vue'),
+          meta: { breadcrumb: 'Analytic Accounts' }
+        },
+        {
+          path: 'accounting/analytic-accounts/new',
+          name: 'analytic-account-new',
+          component: () => import('@/pages/accounting/analytic-accounts/AnalyticAccountFormPage.vue'),
+          meta: { breadcrumb: 'New Analytic Account' }
+        },
+        {
+          path: 'accounting/analytic-accounts/:id/edit',
+          name: 'analytic-account-edit',
+          component: () => import('@/pages/accounting/analytic-accounts/AnalyticAccountFormPage.vue'),
+          meta: { breadcrumb: 'Edit Analytic Account' }
+        },
         // Accounting - Journal Entries routes
         {
           path: 'accounting/journal-entries',


### PR DESCRIPTION
## Summary
- Analytic Accounts list/create/edit under Accounting.
- Journal entry Analytic column is a select from that master (`{ [id]: 100 }`), not free-text `id:pct`.
- Companion to satriyop/enter365#82.

Related to enter365#57.

## Test plan
- [ ] Vitest analytic picker helpers
- [ ] New analytic account from Accounting → Analytic Accounts
- [ ] New JE line Analytic select sets distribution map

## Notes
Do not merge.