### PR TITLE
feat(accounting): tax tag master + JE Tax Grids picker (#58)

### DIFF
--- a/src/api/__tests__/tax-tags.test.ts
+++ b/src/api/__tests__/tax-tags.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import {
+  formatTaxTagLabel,
+  taxTagIdsFromTagId,
+  taxTagIdsPrimaryId,
+} from '../useTaxTags'
+
+describe('tax tag picker helpers', () => {
+  it('maps a selected tax tag to tax_tag_ids', () => {
+    expect(taxTagIdsFromTagId('7')).toEqual([7])
+    expect(taxTagIdsFromTagId(12)).toEqual([12])
+    expect(taxTagIdsFromTagId('')).toBeNull()
+    expect(taxTagIdsFromTagId(null)).toBeNull()
+  })
+
+  it('reads the primary tax tag id', () => {
+    expect(taxTagIdsPrimaryId([7, 8])).toBe('7')
+    expect(taxTagIdsPrimaryId(null)).toBe('')
+  })
+
+  it('labels tax grids using the tax tag master', () => {
+    const tags = [
+      { id: 7, code: 'BASE-PPN', name: 'PPN Base', applicability: 'base' as const, is_active: true },
+      { id: 8, code: 'TAX-PPN', name: 'PPN Tax', applicability: 'tax' as const, is_active: true },
+    ]
+    expect(formatTaxTagLabel([7, 8], tags)).toBe('BASE-PPN PPN Base, TAX-PPN PPN Tax')
+    expect(formatTaxTagLabel([99], tags)).toBe('99')
+    expect(formatTaxTagLabel(null, tags)).toBe('')
+  })
+})

--- a/src/api/useTaxTags.ts
+++ b/src/api/useTaxTags.ts
@@ -1,0 +1,85 @@
+import { createCrudHooks } from './factory'
+
+export type TaxTagApplicability = 'base' | 'tax'
+
+export interface TaxTag {
+  id: number
+  code: string
+  name: string
+  applicability: TaxTagApplicability
+  is_active: boolean
+}
+
+export interface TaxTagFilters {
+  page?: number
+  per_page?: number
+  search?: string
+  applicability?: TaxTagApplicability | ''
+  is_active?: boolean
+}
+
+export interface CreateTaxTagData {
+  code: string
+  name: string
+  applicability?: TaxTagApplicability
+  is_active?: boolean
+}
+
+export type UpdateTaxTagData = Partial<CreateTaxTagData>
+
+const hooks = createCrudHooks<TaxTag, TaxTagFilters, CreateTaxTagData, UpdateTaxTagData>({
+  resourceName: 'tax-tags',
+  singularName: 'tax-tag',
+  lookupParams: { is_active: true, per_page: 200 },
+})
+
+export const useTaxTags = hooks.useList
+export const useTaxTag = hooks.useSingle
+export const useCreateTaxTag = hooks.useCreate
+export const useUpdateTaxTag = hooks.useUpdate
+export const useTaxTagsLookup = hooks.useLookup
+
+export const TAX_TAG_APPLICABILITY_OPTIONS = [
+  { value: 'base', label: 'Base' },
+  { value: 'tax', label: 'Tax' },
+] as const
+
+export function taxTagApplicabilityLabel(value: string): string {
+  return TAX_TAG_APPLICABILITY_OPTIONS.find((option) => option.value === value)?.label ?? value
+}
+
+export function taxTagIdsFromTagId(
+  id: string | number | null | undefined,
+): number[] | null {
+  if (id === null || id === undefined || id === '') {
+    return null
+  }
+  const parsed = Number(id)
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    return null
+  }
+  return [parsed]
+}
+
+export function taxTagIdsPrimaryId(value: number[] | null | undefined): string {
+  if (!value || value.length === 0) {
+    return ''
+  }
+  return String(value[0])
+}
+
+export function formatTaxTagLabel(
+  value: number[] | null | undefined,
+  tags: TaxTag[] | undefined,
+): string {
+  if (!value || value.length === 0) {
+    return ''
+  }
+
+  return value
+    .map((id) => {
+      const tag = tags?.find((row) => row.id === id)
+      return tag ? `${tag.code} ${tag.name}` : String(id)
+    })
+    .join(', ')
+}

--- a/src/config/nav.ts
+++ b/src/config/nav.ts
@@ -75,6 +75,7 @@ export const navigation: NavGroup[] = [
       { name: 'Chart of Accounts', path: '/accounting/accounts', icon: '📒', permission: 'accounts.view' },
       { name: 'Journals', path: '/accounting/journals', icon: '🗂️', permission: 'journals.view' },
       { name: 'Analytic Accounts', path: '/accounting/analytic-accounts', icon: '🎯', permission: 'journals.view' },
+      { name: 'Tax Tags', path: '/accounting/tax-tags', icon: '🏷️', permission: 'journals.view' },
       { name: 'Journal Entries', path: '/accounting/journal-entries', icon: '📝', permission: 'journals.view' },
       { name: 'Fiscal Periods', path: '/accounting/fiscal-periods', icon: '📅', permission: 'fiscal_periods.view' },
       { name: 'Budgets', path: '/accounting/budgets', icon: '📊', permission: 'budgets.view', feature: 'budgeting' },

--- a/src/pages/accounting/journal-entries/JournalEntryDetailPage.vue
+++ b/src/pages/accounting/journal-entries/JournalEntryDetailPage.vue
@@ -7,12 +7,12 @@ import {
   usePostJournalEntry,
   useReverseJournalEntry,
   getJournalEntryStatus,
-  formatTaxTagIds,
 } from '@/api/useJournalEntries'
 import {
   formatAnalyticDistributionLabel,
   useAnalyticAccountsLookup,
 } from '@/api/useAnalyticAccounts'
+import { formatTaxTagLabel, useTaxTagsLookup } from '@/api/useTaxTags'
 import { formatCurrency, formatDate } from '@/utils/format'
 import { Button, Card, Modal, Input, useToast } from '@/components/ui'
 import { ArrowLeft, Trash2, CheckCircle, RotateCcw, AlertTriangle } from 'lucide-vue-next'
@@ -26,6 +26,7 @@ const entryId = computed(() => String(route.params.id))
 // Fetch journal entry
 const { data: entry, isLoading, error, refetch } = useJournalEntry(entryId)
 const { data: analyticAccounts } = useAnalyticAccountsLookup()
+const { data: taxTags } = useTaxTagsLookup()
 
 // Mutations
 const deleteMutation = useDeleteJournalEntry()
@@ -291,7 +292,7 @@ function viewAccount(accountId: string) {
                   {{ formatAnalyticDistributionLabel(line.analytic_distribution, analyticAccounts) || '-' }}
                 </td>
                 <td class="px-4 py-3 font-mono text-slate-600 dark:text-slate-400" data-testid="je-line-tax-grids">
-                  {{ formatTaxTagIds(line.tax_tag_ids) || '-' }}
+                  {{ formatTaxTagLabel(line.tax_tag_ids, taxTags) || '-' }}
                 </td>
                 <td class="px-4 py-3 text-slate-600 dark:text-slate-400">
                   {{ line.description || '-' }}

--- a/src/pages/accounting/journal-entries/JournalEntryFormPage.vue
+++ b/src/pages/accounting/journal-entries/JournalEntryFormPage.vue
@@ -6,8 +6,6 @@ import {
   calculateLineTotals,
   validateJournalLines,
   createEmptyLine,
-  formatTaxTagIds,
-  parseTaxTagIds,
   type CreateJournalEntryData,
   type CreateJournalEntryLineData,
 } from '@/api/useJournalEntries'
@@ -19,6 +17,7 @@ import {
 } from '@/api/useAnalyticAccounts'
 import { useContactsLookup } from '@/api/useContacts'
 import { useJournalsLookup, journalTypeLabel } from '@/api/useJournals'
+import { taxTagIdsFromTagId, taxTagIdsPrimaryId, useTaxTagsLookup } from '@/api/useTaxTags'
 import { formatCurrency } from '@/utils/format'
 import { Button, Card, Input, Select, useToast, CurrencyInput } from '@/components/ui'
 import { ArrowLeft, Save, Loader2, Plus, Trash2, AlertTriangle, CheckCircle } from 'lucide-vue-next'
@@ -31,6 +30,7 @@ const { data: accounts, isLoading: accountsLoading } = useAccountsLookup()
 const { data: journals, isLoading: journalsLoading } = useJournalsLookup()
 const { data: contacts, isLoading: contactsLoading } = useContactsLookup()
 const { data: analyticAccounts, isLoading: analyticAccountsLoading } = useAnalyticAccountsLookup()
+const { data: taxTags, isLoading: taxTagsLoading } = useTaxTagsLookup()
 const journalId = ref<string>('')
 
 
@@ -67,6 +67,14 @@ const analyticOptions = computed(() => {
   }))
 })
 
+const taxTagOptions = computed(() => {
+  if (!taxTags.value) return []
+  return taxTags.value.map((tag) => ({
+    value: String(tag.id),
+    label: `${tag.code} - ${tag.name}`,
+  }))
+})
+
 // Form state
 const entryDate = ref(new Date().toISOString().split('T')[0])
 const description = ref('')
@@ -76,8 +84,7 @@ const lines = ref<CreateJournalEntryLineData[]>([
   createEmptyLine(),
 ])
 
-/** Draft strings for optional tax grids (no tax-tag master yet). */
-const taxTagDrafts = ref<string[]>(['', ''])
+
 
 // Calculate totals
 const totals = computed(() => calculateLineTotals(lines.value))
@@ -94,14 +101,12 @@ const hasErrors = computed(() => validationErrors.value.length > 0)
 // Add new line
 function addLine() {
   lines.value.push(createEmptyLine())
-  taxTagDrafts.value.push('')
 }
 
 // Remove line
 function removeLine(index: number) {
   if (lines.value.length > 2) {
     lines.value.splice(index, 1)
-    taxTagDrafts.value.splice(index, 1)
   }
 }
 
@@ -111,16 +116,10 @@ function onAnalyticSelect(index: number, value: string | number | null) {
   line.analytic_distribution = analyticDistributionFromAccountId(value)
 }
 
-function onTaxTagsInput(index: number, value: string) {
-  taxTagDrafts.value[index] = value
+function onTaxTagSelect(index: number, value: string | number | null) {
   const line = lines.value[index]
   if (!line) return
-  if (!value.trim()) {
-    line.tax_tag_ids = null
-    return
-  }
-  const parsed = parseTaxTagIds(value)
-  if (parsed) line.tax_tag_ids = parsed
+  line.tax_tag_ids = taxTagIdsFromTagId(value)
 }
 
 // Handle debit change - clear credit if debit is entered
@@ -194,23 +193,6 @@ async function handleSubmit() {
   if (hasErrors.value) {
     toast.error('Please fix the errors before submitting')
     return
-  }
-
-  // Commit optional dimension drafts (reject half-typed values)
-  for (let i = 0; i < lines.value.length; i++) {
-    const line = lines.value[i]
-    if (!line) continue
-    const taxRaw = taxTagDrafts.value[i] ?? ''
-    if (taxRaw.trim()) {
-      const parsed = parseTaxTagIds(taxRaw)
-      if (!parsed) {
-        toast.error(`Line ${i + 1}: Tax Grids must be comma-separated positive ids (e.g. 101, 202)`)
-        return
-      }
-      line.tax_tag_ids = parsed
-    } else {
-      line.tax_tag_ids = null
-    }
   }
 
   // Filter out empty lines
@@ -336,7 +318,7 @@ async function handleSubmit() {
                 <th class="px-4 py-3 text-left font-medium text-slate-500 dark:text-slate-400 min-w-[10rem]" title="Analytic account from master — stored as {id: 100}">
                   Analytic
                 </th>
-                <th class="px-4 py-3 text-left font-medium text-slate-500 dark:text-slate-400 min-w-[7rem]" title="Odoo Tax Grids / tax_tag_ids (no tax-tag master yet)">
+                <th class="px-4 py-3 text-left font-medium text-slate-500 dark:text-slate-400 min-w-[10rem]" title="Tax tag from master — stored as tax_tag_ids">
                   Tax Grids
                 </th>
                 <th class="px-4 py-3 text-left font-medium text-slate-500 dark:text-slate-400 w-1/5">
@@ -391,12 +373,13 @@ async function handleSubmit() {
 
                 <!-- Tax Grids -->
                 <td class="px-4 py-2">
-                  <Input
-                    :model-value="taxTagDrafts[index] ?? formatTaxTagIds(line.tax_tag_ids)"
-                    :data-testid="`je-line-${index}-tax-grids`"
-                    placeholder="101, 202"
-                    class="text-sm font-mono"
-                    @update:model-value="(v) => onTaxTagsInput(index, String(v))"
+                  <Select
+                    :test-id="`je-line-${index}-tax-grids`"
+                    :model-value="taxTagIdsPrimaryId(line.tax_tag_ids)"
+                    :options="taxTagOptions"
+                    :loading="taxTagsLoading"
+                    placeholder="Optional"
+                    @update:model-value="(v) => onTaxTagSelect(index, v)"
                   />
                 </td>
 
@@ -516,7 +499,7 @@ async function handleSubmit() {
       <ul class="text-sm text-slate-600 dark:text-slate-400 space-y-2">
         <li>• Partner (customer/vendor) is optional on each line for AR/AP reporting</li>
         <li>• Analytic: pick an analytic account; stored as Odoo analytic_distribution JSON ({id: 100})</li>
-        <li>• Tax Grids: optional comma-separated tag ids — stored as tax_tag_ids; VAT reports remain document-level for now</li>
+        <li>• Tax Grids: pick a tax tag (base or tax); VAT / Tax Summary stay on invoices and bills</li>
         <li>• Each line can only have a debit OR credit amount, not both</li>
         <li>• Total debits must equal total credits for a balanced entry</li>
         <li>• Use "Auto-Balance" to automatically fill the last line</li>

--- a/src/pages/accounting/tax-tags/TaxTagFormPage.vue
+++ b/src/pages/accounting/tax-tags/TaxTagFormPage.vue
@@ -1,0 +1,152 @@
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import {
+  TAX_TAG_APPLICABILITY_OPTIONS,
+  useCreateTaxTag,
+  useTaxTag,
+  useUpdateTaxTag,
+  type TaxTagApplicability,
+} from '@/api/useTaxTags'
+import { Button, Card, Input, Select, useToast } from '@/components/ui'
+import { ArrowLeft, Save, Loader2 } from 'lucide-vue-next'
+
+const route = useRoute()
+const router = useRouter()
+const toast = useToast()
+
+const tagId = computed(() => (route.params.id ? String(route.params.id) : null))
+const isEditing = computed(() => !!tagId.value)
+const pageTitle = computed(() => (isEditing.value ? 'Edit Tax Tag' : 'New Tax Tag'))
+
+const { data: existing, isLoading: loadingTag } = useTaxTag(
+  computed(() => tagId.value ?? ''),
+)
+
+const code = ref('')
+const name = ref('')
+const applicability = ref<TaxTagApplicability>('tax')
+const isActive = ref(true)
+
+watch(existing, (tag) => {
+  if (!tag) return
+  code.value = tag.code
+  name.value = tag.name
+  applicability.value = tag.applicability
+  isActive.value = tag.is_active
+}, { immediate: true })
+
+const createMutation = useCreateTaxTag()
+const updateMutation = useUpdateTaxTag()
+const isSubmitting = computed(() => createMutation.isPending.value || updateMutation.isPending.value)
+
+const statusOptions = [
+  { value: '1', label: 'Active' },
+  { value: '0', label: 'Inactive' },
+]
+
+const applicabilityOptions = TAX_TAG_APPLICABILITY_OPTIONS.map((option) => ({
+  value: option.value,
+  label: option.label,
+}))
+
+async function handleSubmit() {
+  if (!code.value.trim()) {
+    toast.error('Code is required')
+    return
+  }
+  if (!name.value.trim()) {
+    toast.error('Name is required')
+    return
+  }
+
+  const payload = {
+    code: code.value.trim(),
+    name: name.value.trim(),
+    applicability: applicability.value,
+    is_active: isActive.value,
+  }
+
+  try {
+    if (isEditing.value && tagId.value) {
+      await updateMutation.mutateAsync({ id: tagId.value, data: payload })
+      toast.success('Tax tag updated')
+    } else {
+      await createMutation.mutateAsync(payload)
+      toast.success('Tax tag created')
+    }
+    router.push('/accounting/tax-tags')
+  } catch {
+    toast.error(isEditing.value ? 'Failed to update tax tag' : 'Failed to create tax tag')
+  }
+}
+</script>
+
+<template>
+  <div>
+    <div class="flex items-center gap-2 text-sm text-slate-500 dark:text-slate-400 mb-4">
+      <RouterLink to="/accounting/tax-tags" class="hover:text-slate-700 dark:hover:text-slate-300 flex items-center gap-1">
+        <ArrowLeft class="w-4 h-4" />
+        Tax Tags
+      </RouterLink>
+      <span>/</span>
+      <span class="text-slate-900 dark:text-slate-100">{{ pageTitle }}</span>
+    </div>
+
+    <div class="mb-6">
+      <h1 class="text-2xl font-semibold text-slate-900 dark:text-slate-100">{{ pageTitle }}</h1>
+      <p class="text-slate-500 dark:text-slate-400">Used as the journal entry Tax Grids picker</p>
+    </div>
+
+    <div v-if="isEditing && loadingTag" class="py-12 text-center text-slate-500">
+      <Loader2 class="w-5 h-5 animate-spin inline mr-2" />
+      Loading...
+    </div>
+
+    <form v-else @submit.prevent="handleSubmit">
+      <Card class="mb-6 max-w-2xl">
+        <div class="space-y-4">
+          <div>
+            <label class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
+              Code <span class="text-red-500">*</span>
+            </label>
+            <Input v-model="code" data-testid="tax-tag-code" placeholder="e.g. PPN-OUT" />
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
+              Name <span class="text-red-500">*</span>
+            </label>
+            <Input v-model="name" data-testid="tax-tag-name" placeholder="e.g. PPN Keluaran" />
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">Grid</label>
+            <Select
+              :model-value="applicability"
+              :options="applicabilityOptions"
+              :test-id="'tax-tag-applicability'"
+              @update:model-value="(v) => applicability = String(v) as TaxTagApplicability"
+            />
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">Status</label>
+            <Select
+              :model-value="isActive ? '1' : '0'"
+              :options="statusOptions"
+              :test-id="'tax-tag-active'"
+              @update:model-value="(v) => isActive = String(v) === '1'"
+            />
+          </div>
+        </div>
+      </Card>
+
+      <div class="flex items-center gap-3">
+        <Button type="submit" data-testid="tax-tag-submit" :disabled="isSubmitting">
+          <Loader2 v-if="isSubmitting" class="w-4 h-4 mr-2 animate-spin" />
+          <Save v-else class="w-4 h-4 mr-2" />
+          {{ isEditing ? 'Save' : 'Create' }}
+        </Button>
+        <Button type="button" variant="ghost" @click="router.push('/accounting/tax-tags')">Cancel</Button>
+      </div>
+    </form>
+  </div>
+</template>

--- a/src/pages/accounting/tax-tags/TaxTagListPage.vue
+++ b/src/pages/accounting/tax-tags/TaxTagListPage.vue
@@ -1,0 +1,123 @@
+<script setup lang="ts">
+import { useRouter } from 'vue-router'
+import {
+  taxTagApplicabilityLabel,
+  useTaxTags,
+  type TaxTag,
+  type TaxTagFilters,
+} from '@/api/useTaxTags'
+import { useResourceList } from '@/composables/useResourceList'
+import { Button, Input, Card, Pagination, ResponsiveTable, type ResponsiveColumn } from '@/components/ui'
+import { Plus, Search } from 'lucide-vue-next'
+
+const router = useRouter()
+
+const {
+  items: tags,
+  pagination,
+  isLoading,
+  error,
+  isEmpty,
+  filters,
+  updateFilter,
+  goToPage,
+} = useResourceList<TaxTag, TaxTagFilters>({
+  useListHook: useTaxTags,
+  initialFilters: {
+    page: 1,
+    per_page: 50,
+    search: '',
+  },
+})
+
+const columns: ResponsiveColumn[] = [
+  { key: 'code', label: 'Code', mobilePriority: 1 },
+  { key: 'name', label: 'Name', mobilePriority: 2 },
+  { key: 'applicability', label: 'Grid', mobilePriority: 3 },
+  { key: 'is_active', label: 'Status', mobilePriority: 4 },
+]
+
+function editTag(tag: TaxTag) {
+  router.push(`/accounting/tax-tags/${tag.id}/edit`)
+}
+</script>
+
+<template>
+  <div>
+    <div class="flex items-center justify-between mb-6">
+      <div>
+        <h1 class="text-2xl font-semibold text-slate-900 dark:text-slate-100">Tax Tags</h1>
+        <p class="text-slate-500 dark:text-slate-400">
+          Master for journal entry Tax Grids (base / tax). VAT reports stay on invoices and bills.
+        </p>
+      </div>
+      <Button data-testid="tax-tag-create" @click="router.push('/accounting/tax-tags/new')">
+        <Plus class="w-4 h-4 mr-1" />
+        New Tax Tag
+      </Button>
+    </div>
+
+    <Card class="mb-4">
+      <div class="flex flex-col sm:flex-row gap-3 p-4">
+        <div class="relative flex-1">
+          <Search class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400" />
+          <Input
+            :model-value="filters.search ?? ''"
+            class="pl-9"
+            placeholder="Search code or name..."
+            data-testid="tax-tag-search"
+            @update:model-value="(v) => updateFilter('search', String(v))"
+          />
+        </div>
+      </div>
+    </Card>
+
+    <Card>
+      <div v-if="error" class="py-12 text-center text-red-500">Failed to load tax tags</div>
+      <div v-else-if="isEmpty && !isLoading" class="py-12 text-center text-slate-500">No tax tags found</div>
+      <ResponsiveTable
+        v-else
+        :items="tags ?? []"
+        :columns="columns"
+        :loading="isLoading"
+        empty-message="No tax tags found"
+        @row-click="editTag"
+      >
+        <template #cell-code="{ item }">
+          <code class="text-sm">{{ item.code }}</code>
+        </template>
+        <template #cell-name="{ item }">
+          <span class="font-medium text-slate-900 dark:text-slate-100">{{ item.name }}</span>
+        </template>
+        <template #cell-applicability="{ item }">
+          <span class="inline-flex px-2 py-0.5 rounded text-xs bg-slate-100 dark:bg-slate-800">
+            {{ taxTagApplicabilityLabel(item.applicability) }}
+          </span>
+        </template>
+        <template #cell-is_active="{ item }">
+          <span
+            class="inline-flex px-2 py-0.5 rounded text-xs"
+            :class="item.is_active
+              ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
+              : 'bg-slate-100 text-slate-600 dark:bg-slate-700 dark:text-slate-400'"
+          >
+            {{ item.is_active ? 'Active' : 'Inactive' }}
+          </span>
+        </template>
+        <template #actions="{ item }">
+          <Button variant="ghost" size="xs" @click.stop="editTag(item)">Edit</Button>
+        </template>
+      </ResponsiveTable>
+
+      <div v-if="pagination" class="px-6 py-4 border-t border-slate-200 dark:border-slate-700">
+        <Pagination
+          :current-page="pagination.current_page"
+          :total-pages="pagination.last_page"
+          :total="pagination.total"
+          :per-page="pagination.per_page"
+          @page-change="goToPage"
+        />
+      </div>
+    </Card>
+  </div>
+</template>

--- a/src/router/__tests__/access.test.ts
+++ b/src/router/__tests__/access.test.ts
@@ -11,6 +11,8 @@ describe('route permission gates', () => {
     expect(canOpenPath('/accounting/journal-entries', has)).toBe(true)
     expect(canOpenPath('/accounting/analytic-accounts', has)).toBe(true)
     expect(canOpenPath('/accounting/analytic-accounts/new', has)).toBe(false)
+    expect(canOpenPath('/accounting/tax-tags', has)).toBe(true)
+    expect(canOpenPath('/accounting/tax-tags/new', has)).toBe(false)
     expect(canOpenPath('/reports/trial-balance', has)).toBe(true)
     expect(canOpenPath('/reports/stock-summary', has)).toBe(false)
   })

--- a/src/router/access.ts
+++ b/src/router/access.ts
@@ -7,6 +7,8 @@ export const PERMISSION_ROUTE_PREFIXES: Array<{ prefix: string; permission: stri
   { prefix: '/accounting/journals', permission: 'journals.view' },
   { prefix: '/accounting/analytic-accounts/new', permission: 'journals.create' },
   { prefix: '/accounting/analytic-accounts', permission: 'journals.view' },
+  { prefix: '/accounting/tax-tags/new', permission: 'journals.create' },
+  { prefix: '/accounting/tax-tags', permission: 'journals.view' },
   { prefix: '/accounting/journal-entries/new', permission: 'journals.create' },
   { prefix: '/accounting/journal-entries', permission: 'journals.view' },
   { prefix: '/reports/stock-summary', permission: 'inventory.view' },

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -552,6 +552,24 @@ const router = createRouter({
           component: () => import('@/pages/accounting/analytic-accounts/AnalyticAccountFormPage.vue'),
           meta: { breadcrumb: 'Edit Analytic Account' }
         },
+        {
+          path: 'accounting/tax-tags',
+          name: 'tax-tags',
+          component: () => import('@/pages/accounting/tax-tags/TaxTagListPage.vue'),
+          meta: { breadcrumb: 'Tax Tags' }
+        },
+        {
+          path: 'accounting/tax-tags/new',
+          name: 'tax-tag-new',
+          component: () => import('@/pages/accounting/tax-tags/TaxTagFormPage.vue'),
+          meta: { breadcrumb: 'New Tax Tag' }
+        },
+        {
+          path: 'accounting/tax-tags/:id/edit',
+          name: 'tax-tag-edit',
+          component: () => import('@/pages/accounting/tax-tags/TaxTagFormPage.vue'),
+          meta: { breadcrumb: 'Edit Tax Tag' }
+        },
         // Accounting - Journal Entries routes
         {
           path: 'accounting/journal-entries',


### PR DESCRIPTION
## Summary
- Tax Tags list/create/edit under Accounting (base / tax grids).
- Journal entry Tax Grids column is a select from that master (`tax_tag_ids: [id]`), not free-text ids.
- Companion to satriyop/enter365#83. Stacked on FE analytic-account-master (#57 / #56).

Related to enter365#58.

## Test plan
- [ ] Vitest tax tag picker helpers
- [ ] New tax tag from Accounting → Tax Tags
- [ ] New JE line Tax Grids select sets tax_tag_ids

## Notes
Do not merge.