### PR TITLE
feat(reports): Partner Ledger Invoice Date, Due Date, Matching (#74)

### DIFF
--- a/src/api/useReports.ts
+++ b/src/api/useReports.ts
@@ -186,6 +186,9 @@ export interface PartnerLedgerEntry {
   account_name: string
   description: string
   reference: string | null
+  invoice_date: string | null
+  due_date: string | null
+  matching: string | null
   debit: number
   credit: number
   balance: number

--- a/src/pages/reports/PartnerLedgerPage.vue
+++ b/src/pages/reports/PartnerLedgerPage.vue
@@ -172,6 +172,9 @@ function handleExport() {
                     <th class="px-6 py-3 text-left text-xs font-medium text-slate-700 dark:text-slate-300 uppercase tracking-wider">Date</th>
                     <th class="px-6 py-3 text-left text-xs font-medium text-slate-700 dark:text-slate-300 uppercase tracking-wider">Journal</th>
                     <th class="px-6 py-3 text-left text-xs font-medium text-slate-700 dark:text-slate-300 uppercase tracking-wider">Account</th>
+                    <th class="px-6 py-3 text-left text-xs font-medium text-slate-700 dark:text-slate-300 uppercase tracking-wider">Invoice Date</th>
+                    <th class="px-6 py-3 text-left text-xs font-medium text-slate-700 dark:text-slate-300 uppercase tracking-wider">Due Date</th>
+                    <th class="px-6 py-3 text-left text-xs font-medium text-slate-700 dark:text-slate-300 uppercase tracking-wider">Matching</th>
                     <th class="px-6 py-3 text-left text-xs font-medium text-slate-700 dark:text-slate-300 uppercase tracking-wider">Description</th>
                     <th class="px-6 py-3 text-right text-xs font-medium text-slate-700 dark:text-slate-300 uppercase tracking-wider">Debit</th>
                     <th class="px-6 py-3 text-right text-xs font-medium text-slate-700 dark:text-slate-300 uppercase tracking-wider">Credit</th>
@@ -187,13 +190,16 @@ function handleExport() {
                     <td class="px-6 py-4 whitespace-nowrap text-sm text-slate-900 dark:text-slate-100">{{ formatDate(entry.date) }}</td>
                     <td class="px-6 py-4 whitespace-nowrap text-sm text-slate-900 dark:text-slate-100">{{ entry.journal || entry.entry_number }}</td>
                     <td class="px-6 py-4 whitespace-nowrap text-sm text-slate-900 dark:text-slate-100">{{ entry.account_code }}</td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-slate-900 dark:text-slate-100">{{ entry.invoice_date ? formatDate(entry.invoice_date) : '—' }}</td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-slate-900 dark:text-slate-100">{{ entry.due_date ? formatDate(entry.due_date) : '—' }}</td>
+                    <td class="px-6 py-4 whitespace-nowrap text-sm text-slate-900 dark:text-slate-100">{{ entry.matching || '—' }}</td>
                     <td class="px-6 py-4 text-sm text-slate-900 dark:text-slate-100">{{ entry.description }}</td>
                     <td class="px-6 py-4 whitespace-nowrap text-sm text-right text-slate-900 dark:text-slate-100">{{ entry.debit ? formatCurrency(entry.debit) : '-' }}</td>
                     <td class="px-6 py-4 whitespace-nowrap text-sm text-right text-slate-900 dark:text-slate-100">{{ entry.credit ? formatCurrency(entry.credit) : '-' }}</td>
                     <td class="px-6 py-4 whitespace-nowrap text-sm text-right font-medium text-slate-900 dark:text-slate-100">{{ formatCurrency(entry.balance) }}</td>
                   </tr>
                   <tr class="bg-slate-50 dark:bg-slate-800/50 font-semibold">
-                    <td colspan="6" class="px-6 py-4 text-sm text-slate-900 dark:text-slate-100">Closing Balance</td>
+                    <td colspan="9" class="px-6 py-4 text-sm text-slate-900 dark:text-slate-100">Closing Balance</td>
                     <td class="px-6 py-4 whitespace-nowrap text-sm text-right text-slate-900 dark:text-slate-100">{{ formatCurrency(partner.closing_balance) }}</td>
                   </tr>
                 </tbody>

--- a/src/pages/reports/__tests__/reportFiltersExports.test.ts
+++ b/src/pages/reports/__tests__/reportFiltersExports.test.ts
@@ -24,6 +24,16 @@ describe('report filters and exports (#37)', () => {
     expect(source).toContain('All Journals')
   })
 
+  it('shows Invoice Date, Due Date, and Matching on partner ledger lines (#74)', () => {
+    const source = pageSource('PartnerLedgerPage.vue')
+    expect(source).toContain('Invoice Date')
+    expect(source).toContain('Due Date')
+    expect(source).toContain('Matching')
+    expect(source).toContain('entry.invoice_date')
+    expect(source).toContain('entry.due_date')
+    expect(source).toContain('entry.matching')
+  })
+
   it('offers comparison on balance sheet, income statement, and cash flow', () => {
     expect(pageSource('BalanceSheetPage.vue')).toContain('compareTo')
     expect(pageSource('IncomeStatementPage.vue')).toContain('comparePreviousPeriod')


### PR DESCRIPTION
## Summary
- Partner Ledger line table adds **Invoice Date**, **Due Date**, and **Matching**.
- Types include `invoice_date`, `due_date`, `matching` from the API (#74 / enter365 PR).

Companion to satriyop/enter365 Partner Ledger residual.

Related to satriyop/enter365#74.

## Test plan
- [ ] Vitest `reportFiltersExports.test.ts`
- [ ] Expanded partner shows the three new columns

## Notes
Do not merge.