### PR TITLE
feat(journals): multi-account analytic distribution percentages (#86)

### DIFF
--- a/src/api/__tests__/analytic-accounts.test.ts
+++ b/src/api/__tests__/analytic-accounts.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import {
   analyticDistributionFromAccountId,
+  analyticDistributionFromRows,
+  analyticDistributionPercentTotal,
   analyticDistributionPrimaryId,
+  analyticDistributionRows,
   formatAnalyticDistributionLabel,
 } from '../useAnalyticAccounts'
 
@@ -17,6 +20,18 @@ describe('analytic account picker helpers', () => {
     expect(analyticDistributionPrimaryId({ '7': 100 })).toBe('7')
     expect(analyticDistributionPrimaryId({ '3': 60, '4': 40 })).toBe('3')
     expect(analyticDistributionPrimaryId(null)).toBe('')
+  })
+
+  it('round-trips multi-account percentage rows summing to 100', () => {
+    const rows = analyticDistributionRows({ '3': 60, '4': 40 })
+    expect(rows).toEqual([
+      { id: '3', percentage: 60 },
+      { id: '4', percentage: 40 },
+    ])
+    expect(analyticDistributionFromRows(rows)).toEqual({ '3': 60, '4': 40 })
+    expect(analyticDistributionPercentTotal(rows)).toBe(100)
+    expect(analyticDistributionFromRows([{ id: '', percentage: 100 }])).toBeNull()
+    expect(analyticDistributionPercentTotal([{ id: '3', percentage: 60 }, { id: '4', percentage: 30 }])).toBe(90)
   })
 
   it('labels distribution using analytic account master rows', () => {

--- a/src/api/__tests__/journal-entry-dimensions.test.ts
+++ b/src/api/__tests__/journal-entry-dimensions.test.ts
@@ -4,6 +4,8 @@ import {
   parseAnalyticDistribution,
   formatTaxTagIds,
   parseTaxTagIds,
+  validateJournalLines,
+  type CreateJournalEntryLineData,
 } from '../useJournalEntries'
 
 describe('JE line analytic / tax grid helpers', () => {
@@ -16,6 +18,20 @@ describe('JE line analytic / tax grid helpers', () => {
     expect(parseAnalyticDistribution('bad')).toBeNull()
     expect(formatAnalyticDistribution({ '1': 100 })).toBe('1:100')
     expect(formatAnalyticDistribution(null)).toBe('')
+  })
+
+  it('rejects analytic splits that do not sum to 100 percent', () => {
+    const balanced: CreateJournalEntryLineData[] = [
+      { account_id: 1, debit: 100, credit: 0, analytic_distribution: { '3': 60, '4': 40 } },
+      { account_id: 2, debit: 0, credit: 100, analytic_distribution: null },
+    ]
+    expect(validateJournalLines(balanced)).toEqual([])
+
+    const unbalanced: CreateJournalEntryLineData[] = [
+      { account_id: 1, debit: 100, credit: 0, analytic_distribution: { '3': 60, '4': 30 } },
+      { account_id: 2, debit: 0, credit: 100, analytic_distribution: null },
+    ]
+    expect(validateJournalLines(unbalanced).some((error) => error.includes('sum to 100%'))).toBe(true)
   })
 
   it('parses and formats tax_tag_ids', () => {

--- a/src/api/useAnalyticAccounts.ts
+++ b/src/api/useAnalyticAccounts.ts
@@ -39,6 +39,42 @@ export const useCreateAnalyticAccount = hooks.useCreate
 export const useUpdateAnalyticAccount = hooks.useUpdate
 export const useAnalyticAccountsLookup = hooks.useLookup
 
+export interface AnalyticDistributionRow {
+  id: string
+  percentage: number
+}
+
+export function analyticDistributionRows(
+  value: { [key: string]: number } | null | undefined,
+): AnalyticDistributionRow[] {
+  if (!value) {
+    return []
+  }
+
+  return Object.entries(value).map(([id, percentage]) => ({
+    id,
+    percentage: Number(percentage),
+  }))
+}
+
+export function analyticDistributionFromRows(
+  rows: AnalyticDistributionRow[],
+): { [key: string]: number } | null {
+  const map: { [key: string]: number } = {}
+  for (const row of rows) {
+    if (!row.id) {
+      continue
+    }
+    map[row.id] = Number(row.percentage) || 0
+  }
+
+  return Object.keys(map).length === 0 ? null : map
+}
+
+export function analyticDistributionPercentTotal(rows: AnalyticDistributionRow[]): number {
+  return rows.reduce((sum, row) => sum + (Number(row.percentage) || 0), 0)
+}
+
 export function analyticDistributionFromAccountId(
   id: string | number | null | undefined,
 ): { [key: string]: number } | null {

--- a/src/api/useJournalEntries.ts
+++ b/src/api/useJournalEntries.ts
@@ -155,6 +155,14 @@ export function validateJournalLines(lines: CreateJournalEntryLineData[]): strin
     if (debit < 0 || credit < 0) {
       errors.push(`Line ${index + 1}: Amounts cannot be negative`)
     }
+
+    const distribution = line.analytic_distribution
+    if (distribution && Object.keys(distribution).length > 0) {
+      const percentTotal = Object.values(distribution).reduce((sum, pct) => sum + Number(pct || 0), 0)
+      if (Math.abs(percentTotal - 100) > 0.01) {
+        errors.push(`Line ${index + 1}: Analytic distribution must sum to 100%`)
+      }
+    }
   })
 
   const { isBalanced, difference } = calculateLineTotals(lines)

--- a/src/pages/accounting/journal-entries/JournalEntryFormPage.vue
+++ b/src/pages/accounting/journal-entries/JournalEntryFormPage.vue
@@ -11,8 +11,10 @@ import {
 } from '@/api/useJournalEntries'
 import { useAccountsLookup } from '@/api/useAccounts'
 import {
-  analyticDistributionFromAccountId,
-  analyticDistributionPrimaryId,
+  analyticDistributionFromRows,
+  analyticDistributionPercentTotal,
+  analyticDistributionRows,
+  type AnalyticDistributionRow,
   useAnalyticAccountsLookup,
 } from '@/api/useAnalyticAccounts'
 import { useContactsLookup } from '@/api/useContacts'
@@ -110,10 +112,37 @@ function removeLine(index: number) {
   }
 }
 
-function onAnalyticSelect(index: number, value: string | number | null) {
+const analyticDrafts = ref<Record<number, AnalyticDistributionRow[]>>({})
+
+function analyticRowsFor(index: number): AnalyticDistributionRow[] {
+  return analyticDrafts.value[index] ?? analyticDistributionRows(lines.value[index]?.analytic_distribution)
+}
+
+function commitAnalyticRows(index: number, rows: AnalyticDistributionRow[]) {
+  analyticDrafts.value = { ...analyticDrafts.value, [index]: rows }
   const line = lines.value[index]
   if (!line) return
-  line.analytic_distribution = analyticDistributionFromAccountId(value)
+  line.analytic_distribution = analyticDistributionFromRows(rows)
+}
+
+function addAnalyticRow(index: number) {
+  const rows = [...analyticRowsFor(index)]
+  const remaining = Math.max(0, 100 - analyticDistributionPercentTotal(rows))
+  rows.push({ id: '', percentage: remaining })
+  commitAnalyticRows(index, rows)
+}
+
+function updateAnalyticRow(index: number, rowIndex: number, patch: Partial<AnalyticDistributionRow>) {
+  const rows = [...analyticRowsFor(index)]
+  const current = rows[rowIndex] ?? { id: '', percentage: 0 }
+  rows[rowIndex] = { ...current, ...patch }
+  commitAnalyticRows(index, rows)
+}
+
+function removeAnalyticRow(index: number, rowIndex: number) {
+  const rows = [...analyticRowsFor(index)]
+  rows.splice(rowIndex, 1)
+  commitAnalyticRows(index, rows)
 }
 
 function onTaxTagSelect(index: number, value: string | number | null) {
@@ -360,15 +389,53 @@ async function handleSubmit() {
                 </td>
 
                 <!-- Analytic Distribution -->
-                <td class="px-4 py-2">
-                  <Select
-                    :test-id="`je-line-${index}-analytic`"
-                    :model-value="analyticDistributionPrimaryId(line.analytic_distribution)"
-                    :options="analyticOptions"
-                    :loading="analyticAccountsLoading"
-                    placeholder="Optional"
-                    @update:model-value="(v) => onAnalyticSelect(index, v)"
-                  />
+                <td class="px-4 py-2 min-w-[220px]">
+                  <div class="flex flex-col gap-1">
+                    <div
+                      v-for="(row, rowIndex) in analyticRowsFor(index)"
+                      :key="`${index}-analytic-${rowIndex}`"
+                      class="flex items-center gap-1"
+                    >
+                      <Select
+                        :test-id="rowIndex === 0 ? `je-line-${index}-analytic` : `je-line-${index}-analytic-${rowIndex}`"
+                        :model-value="row.id"
+                        :options="analyticOptions"
+                        :loading="analyticAccountsLoading"
+                        placeholder="Account"
+                        @update:model-value="(v) => updateAnalyticRow(index, rowIndex, { id: v ? String(v) : '' })"
+                      />
+                      <Input
+                        :model-value="String(row.percentage)"
+                        :data-testid="`je-line-${index}-analytic-pct-${rowIndex}`"
+                        type="number"
+                        min="0"
+                        max="100"
+                        class="w-16 text-sm"
+                        @update:model-value="(v) => updateAnalyticRow(index, rowIndex, { percentage: Number(v) || 0 })"
+                      />
+                      <span class="text-xs text-slate-500">%</span>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        :data-testid="`je-line-${index}-analytic-remove-${rowIndex}`"
+                        @click="removeAnalyticRow(index, rowIndex)"
+                      >
+                        <Trash2 class="h-3.5 w-3.5" />
+                      </Button>
+                    </div>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      :data-testid="`je-line-${index}-analytic-add`"
+                      class="self-start"
+                      @click="addAnalyticRow(index)"
+                    >
+                      <Plus class="h-3.5 w-3.5 mr-1" />
+                      Add a Line
+                    </Button>
+                  </div>
                 </td>
 
                 <!-- Tax Grids -->
@@ -498,7 +565,7 @@ async function handleSubmit() {
       </template>
       <ul class="text-sm text-slate-600 dark:text-slate-400 space-y-2">
         <li>• Partner (customer/vendor) is optional on each line for AR/AP reporting</li>
-        <li>• Analytic: pick an analytic account; stored as Odoo analytic_distribution JSON ({id: 100})</li>
+        <li>• Analytic: add one or more analytic accounts with percentages that sum to 100%</li>
         <li>• Tax Grids: pick a tax tag (base or tax); VAT / Tax Summary stay on invoices and bills</li>
         <li>• Each line can only have a debit OR credit amount, not both</li>
         <li>• Total debits must equal total credits for a balanced entry</li>


### PR DESCRIPTION
## Summary
- Journal Entry create: Analytic Distribution is a multi-row editor (account + % + **Add a Line**).
- Client validation requires splits to sum to 100% (API does the same).
- Helpers round-trip `{id: pct}` maps to rows.

Companion to satriyop/enter365#93. Related to satriyop/enter365#86.

## Test plan
- [ ] Vitest analytic-accounts + journal-entry-dimensions
- [ ] Add two analytic rows 60/40 and submit

## Notes
Do not merge.