### PR TITLE
feat(bills): Credit Note reverses AP journal, not a purchase return (#88)

### DIFF
--- a/src/api/useBills.ts
+++ b/src/api/useBills.ts
@@ -67,15 +67,15 @@ export function useBillCreditNote() {
       data,
     }: {
       id: number
-      data?: { return_date?: string; warehouse_id?: number; reason?: string; notes?: string }
+      data?: { reason: string; notes?: string }
     }) => {
-      const response = await api.post<{ data: { id: number } }>(`/bills/${id}/credit-note`, data ?? {})
+      const response = await api.post<{ data: { id: number; source_type?: string } }>(`/bills/${id}/credit-note`, data ?? {})
       return response.data.data
     },
     onSuccess: (_, { id }) => {
       queryClient.invalidateQueries({ queryKey: ['bills'] })
       queryClient.invalidateQueries({ queryKey: ['bill', id] })
-      queryClient.invalidateQueries({ queryKey: ['purchase-returns'] })
+      queryClient.invalidateQueries({ queryKey: ['journal-entries'] })
     },
   })
 }

--- a/src/pages/bills/BillDetailPage.vue
+++ b/src/pages/bills/BillDetailPage.vue
@@ -42,7 +42,9 @@ const showVoidModal = ref(false)
 const showDeleteModal = ref(false)
 const showRecurringModal = ref(false)
 const showCreatePRModal = ref(false)
+const showCreditNoteModal = ref(false)
 const voidReason = ref('')
+const creditNoteReason = ref('')
 
 // Make Recurring form
 const today = new Date().toISOString().split('T')[0] || ''
@@ -134,13 +136,19 @@ async function handleVoid() {
 }
 
 async function handleCreditNote() {
+  if (!creditNoteReason.value.trim()) {
+    toast.error('Alasan nota kredit wajib diisi')
+    return
+  }
   try {
     const creditNote = await creditNoteMutation.mutateAsync({
       id: billId.value,
-      data: { reason: 'vendor_request' },
+      data: { reason: creditNoteReason.value.trim() },
     })
-    toast.success('Vendor credit note created')
-    router.push(`/purchasing/purchase-returns/${creditNote.id}`)
+    showCreditNoteModal.value = false
+    creditNoteReason.value = ''
+    toast.success('Nota kredit vendor (pembalikan jurnal) dibuat')
+    router.push(`/accounting/journal-entries/${creditNote.id}`)
   } catch {
     toast.error('Failed to create credit note')
   }
@@ -288,7 +296,7 @@ const journalItemColumns: ResponsiveColumn[] = [
               size="sm"
               data-testid="bill-credit-note"
               :loading="creditNoteMutation.isPending.value"
-              @click="handleCreditNote"
+              @click="showCreditNoteModal = true"
             >
               Credit Note
             </Button>
@@ -546,6 +554,22 @@ const journalItemColumns: ResponsiveColumn[] = [
         </div>
       </div>
     </template>
+
+    <Modal :open="showCreditNoteModal" title="Vendor Credit Note" @update:open="showCreditNoteModal = $event">
+      <p class="text-muted-foreground mb-4">
+        Membalik jurnal tagihan (utang usaha). Retur stok tetap lewat Create Purchase Return.
+      </p>
+      <div class="mb-4">
+        <label class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">Reason</label>
+        <Textarea v-model="creditNoteReason" data-testid="bill-credit-note-reason" :rows="3" placeholder="Alasan nota kredit..." />
+      </div>
+      <template #footer>
+        <Button variant="ghost" @click="showCreditNoteModal = false">Cancel</Button>
+        <Button data-testid="bill-credit-note-submit" :loading="creditNoteMutation.isPending.value" @click="handleCreditNote">
+          Reverse
+        </Button>
+      </template>
+    </Modal>
 
     <!-- Void Modal -->
     <Modal :open="showVoidModal" title="Void Bill" @update:open="showVoidModal = $event">

--- a/src/pages/bills/__tests__/creditNote.test.ts
+++ b/src/pages/bills/__tests__/creditNote.test.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+describe('bill vendor credit note (#88)', () => {
+  it('reverses the bill journal instead of creating a purchase return', () => {
+    const page = readFileSync(resolve(__dirname, '../BillDetailPage.vue'), 'utf8')
+    const api = readFileSync(resolve(__dirname, '../../../api/useBills.ts'), 'utf8')
+
+    expect(page).toContain('/accounting/journal-entries/${creditNote.id}')
+    expect(page).not.toContain('/purchasing/purchase-returns/${creditNote.id}')
+    expect(page).toContain('showCreditNoteModal')
+    expect(api).toContain("queryKey: ['journal-entries']")
+    expect(api).not.toContain("queryKey: ['purchase-returns']")
+  })
+})


### PR DESCRIPTION
## Summary
- Bill **Credit Note** opens a reason modal and navigates to the reversal journal entry.
- No longer creates/navigates to a Purchase Return. Inventory return remains Create Purchase Return.

Companion to satriyop/enter365#95. Related to satriyop/enter365#88.

## Test plan
- [ ] Vitest `creditNote.test.ts`
- [ ] Posted bill → Credit Note → `/accounting/journal-entries/:id`

## Notes
Do not merge.