### PR TITLE
feat(contacts): Contacts tab, address roles, Persons/Companies filters (#98)

### DIFF
--- a/src/api/useContacts.ts
+++ b/src/api/useContacts.ts
@@ -8,14 +8,22 @@ import type { components } from './types'
 // Types
 // ============================================
 
-export type Contact = components['schemas']['ContactResource']
+export type ContactAddressRole = 'invoice' | 'delivery' | 'contact'
+
+export type Contact = components['schemas']['ContactResource'] & {
+  address_role?: ContactAddressRole | null
+  children?: Contact[]
+  parent?: Contact | null
+}
 
 export interface ContactFilters {
   page?: number
   per_page?: number
   type?: 'customer' | 'supplier' | 'both'
+  kind?: 'persons' | 'companies'
   search?: string
   is_active?: boolean
+  is_company?: boolean
 }
 
 export type CreateContactData = components['schemas']['StoreContactRequest']
@@ -58,6 +66,10 @@ export const useDeleteContact = hooks.useDelete
  */
 export function useContactsLookup(type?: 'customer' | 'supplier') {
   return hooks.useLookup({ type })
+}
+
+export function useCompanyContactsLookup() {
+  return hooks.useLookup({ is_company: true, is_active: true })
 }
 
 /**

--- a/src/pages/contacts/ContactDetailPage.vue
+++ b/src/pages/contacts/ContactDetailPage.vue
@@ -154,6 +154,35 @@ const subcontractorServicesDisplay = computed(() => {
             </dl>
           </Card>
 
+          <Card v-if="contact.is_company" data-testid="contact-children-tab">
+            <template #header>
+              <div class="flex items-center justify-between">
+                <h2 class="font-semibold text-slate-900 dark:text-slate-100">Contacts</h2>
+                <RouterLink :to="`/contacts/new?parent_id=${contact.id}`">
+                  <Button size="sm" data-testid="contact-add-child">Add Contact</Button>
+                </RouterLink>
+              </div>
+            </template>
+
+            <div v-if="!contact.children?.length" class="text-sm text-slate-500 dark:text-slate-400">
+              No nested contacts yet. Add invoice, delivery, or other contacts under this company.
+            </div>
+            <ul v-else class="divide-y divide-slate-200 dark:divide-slate-700">
+              <li v-for="child in contact.children" :key="child.id" class="py-3 flex items-center justify-between gap-3">
+                <div>
+                  <RouterLink :to="`/contacts/${child.id}`" class="font-medium text-slate-900 dark:text-slate-100 hover:text-orange-600">
+                    {{ child.name }}
+                  </RouterLink>
+                  <p class="text-sm text-slate-500 dark:text-slate-400 capitalize">
+                    {{ child.address_role || 'contact' }}
+                    <span v-if="child.job_position"> · {{ child.job_position }}</span>
+                  </p>
+                </div>
+                <span class="text-xs font-mono text-slate-400">{{ child.code }}</span>
+              </li>
+            </ul>
+          </Card>
+
           <!-- Address -->
           <Card>
             <template #header>

--- a/src/pages/contacts/ContactFormPage.vue
+++ b/src/pages/contacts/ContactFormPage.vue
@@ -7,6 +7,7 @@ import {
   useContact,
   useCreateContact,
   useUpdateContact,
+  useCompanyContactsLookup,
   type CreateContactData
 } from '@/api/useContacts'
 import { getErrorMessage } from '@/api/client'
@@ -51,6 +52,7 @@ const { errors, handleSubmit, setValues, setErrors, meta, validateField, defineF
     type: 'customer',
     is_company: true,
     parent_id: null,
+    address_role: null,
     job_position: '',
     email: '',
     phone: '',
@@ -86,7 +88,20 @@ const [name] = defineField('name')
 const [type] = defineField('type')
 const [isCompany] = defineField('is_company')
 const [parentId] = defineField('parent_id')
+const [addressRole] = defineField('address_role')
 const [jobPosition] = defineField('job_position')
+
+const { data: companyContacts, isLoading: companiesLoading } = useCompanyContactsLookup()
+const companyOptions = computed(() =>
+  (companyContacts.value ?? [])
+    .filter((company) => company.id !== contactId.value)
+    .map((company) => ({ value: String(company.id), label: `${company.code} · ${company.name}` })),
+)
+const addressRoleOptions = [
+  { value: 'invoice', label: 'Invoice' },
+  { value: 'delivery', label: 'Delivery' },
+  { value: 'contact', label: 'Contact' },
+]
 const [email] = defineField('email')
 const [phone] = defineField('phone')
 const [address] = defineField('address')
@@ -168,6 +183,7 @@ watch(existingContact, (contact) => {
       type: contact.type as 'customer' | 'supplier' | 'both',
       is_company: contact.is_company ?? true,
       parent_id: contact.parent_id ?? null,
+      address_role: contact.address_role ?? null,
       job_position: contact.job_position || '',
       email: contact.email || '',
       phone: contact.phone || '',
@@ -202,6 +218,21 @@ watch(existingContact, (contact) => {
   }
 }, { immediate: true })
 
+watch(
+  () => route.query.parent_id,
+  (parentQuery) => {
+    if (isEditing.value || !parentQuery) {
+      return
+    }
+    isCompany.value = false
+    parentId.value = Number(parentQuery)
+    if (!addressRole.value) {
+      addressRole.value = 'contact'
+    }
+  },
+  { immediate: true },
+)
+
 // Form submission
 const createMutation = useCreateContact()
 const updateMutation = useUpdateContact()
@@ -215,6 +246,7 @@ const onSubmit = handleSubmit(async (formValues) => {
     is_pkp?: boolean
     is_company?: boolean
     parent_id?: number | null
+    address_role?: 'invoice' | 'delivery' | 'contact' | null
     job_position?: string | null
     address_line_2?: string | null
     country?: string | null
@@ -224,6 +256,7 @@ const onSubmit = handleSubmit(async (formValues) => {
     type: formValues.type,
     is_company: formValues.is_company ?? true,
     parent_id: formValues.is_company ? null : (formValues.parent_id ?? null),
+    address_role: formValues.is_company ? null : (formValues.address_role ?? 'contact'),
     job_position: formValues.is_company ? null : (formValues.job_position || null),
     email: formValues.email || null,
     phone: formValues.phone || null,
@@ -347,8 +380,25 @@ useFormShortcuts({
             <Input v-model="jobPosition" placeholder="Purchasing, Billing, Delivery..." />
           </FormField>
 
-          <FormField v-if="!isCompany" label="Parent Company ID" :error="errors.parent_id">
-            <Input v-model.number="parentId" type="number" min="1" placeholder="Company contact id" />
+          <FormField v-if="!isCompany" label="Parent Company" :error="errors.parent_id">
+            <Select
+              :model-value="parentId ? String(parentId) : ''"
+              :options="companyOptions"
+              :loading="companiesLoading"
+              placeholder="Select company"
+              test-id="contact-parent-company"
+              @update:model-value="(v) => { parentId = v ? Number(v) : null }"
+            />
+          </FormField>
+
+          <FormField v-if="!isCompany" label="Address Role" :error="errors.address_role">
+            <Select
+              :model-value="addressRole ?? 'contact'"
+              :options="addressRoleOptions"
+              placeholder="Contact"
+              test-id="contact-address-role"
+              @update:model-value="(v) => { addressRole = v ? String(v) as 'invoice' | 'delivery' | 'contact' : 'contact' }"
+            />
           </FormField>
 
           <FormField label="Name" required :error="errors.name" class="md:col-span-2">

--- a/src/pages/contacts/ContactListPage.vue
+++ b/src/pages/contacts/ContactListPage.vue
@@ -22,6 +22,7 @@ const {
     page: 1,
     per_page: 10,
     type: undefined,
+    kind: undefined,
     search: '',
     is_active: undefined,
   },
@@ -33,6 +34,12 @@ const typeOptions = [
   { value: 'customer', label: 'Customers' },
   { value: 'supplier', label: 'Suppliers' },
   { value: 'both', label: 'Both' },
+]
+
+const kindOptions = [
+  { value: '', label: 'Persons & Companies' },
+  { value: 'persons', label: 'Persons' },
+  { value: 'companies', label: 'Companies' },
 ]
 
 // Status options
@@ -113,6 +120,15 @@ async function handleDelete() {
             v-model="filters.type"
             :options="typeOptions"
             placeholder="All Types"
+          />
+        </div>
+
+        <div class="w-48">
+          <Select
+            v-model="filters.kind"
+            :options="kindOptions"
+            placeholder="Persons & Companies"
+            test-id="contact-kind-filter"
           />
         </div>
 

--- a/src/pages/contacts/__tests__/contactNested.test.ts
+++ b/src/pages/contacts/__tests__/contactNested.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+describe('contact nested company journey (#98)', () => {
+  it('filters persons and companies and uses a parent company picker', () => {
+    const list = readFileSync(resolve(__dirname, '../ContactListPage.vue'), 'utf8')
+    const form = readFileSync(resolve(__dirname, '../ContactFormPage.vue'), 'utf8')
+    const detail = readFileSync(resolve(__dirname, '../ContactDetailPage.vue'), 'utf8')
+
+    expect(list).toContain('Persons')
+    expect(list).toContain('Companies')
+    expect(list).toContain('kindOptions')
+    expect(form).toContain('Parent Company')
+    expect(form).not.toContain('Parent Company ID')
+    expect(form).toContain('useCompanyContactsLookup')
+    expect(form).toContain('address_role')
+    expect(detail).toContain('Add Contact')
+    expect(detail).toContain('contact-children-tab')
+    expect(detail).toContain('parent_id=${contact.id}')
+  })
+})

--- a/src/utils/__tests__/validation.test.ts
+++ b/src/utils/__tests__/validation.test.ts
@@ -128,6 +128,21 @@ describe('contactSchema person/company', () => {
       expect(person.data.parent_id).toBe(9)
     }
   })
+
+  it('accepts invoice delivery and contact address roles', () => {
+    const result = contactSchema.safeParse({
+      code: 'PE-2',
+      name: 'Billing',
+      type: 'customer',
+      is_company: false,
+      parent_id: 9,
+      address_role: 'invoice',
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.address_role).toBe('invoice')
+    }
+  })
 })
 
 describe('nikSchema', () => {

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -160,6 +160,7 @@ export const contactSchema = z.object({
   }),
   is_company: z.boolean().optional().default(true),
   parent_id: z.number().int().positive().optional().nullable(),
+  address_role: z.enum(['invoice', 'delivery', 'contact']).optional().nullable(),
   job_position: z.string().max(100).optional().default(''),
   email: emailSchema,
   phone: phoneSchema,


### PR DESCRIPTION
## Summary
- List filters include **Persons** and **Companies**.
- Company detail **Contacts** tab with **Add Contact**.
- Person form uses a parent **company picker** and invoice/delivery/contact address role.

Companion to satriyop/enter365#103. Related to satriyop/enter365#98.

## Test plan
- [ ] Vitest `contactNested.test.ts` + contactSchema address_role
- [ ] Company detail Add Contact → `/contacts/new?parent_id=`