### PR TITLE
feat(reports): PDF/XLSX export, journal filters, Posted Entries (#99)

### DIFF
--- a/src/api/useExports.ts
+++ b/src/api/useExports.ts
@@ -40,7 +40,7 @@ function today() {
  */
 export function useExportTrialBalance() {
   return useMutation({
-    mutationFn: async (params?: { date?: string; format?: string }) => {
+    mutationFn: async (params?: { date?: string; format?: string; journal_id?: string; posted_only?: boolean }) => {
       const format = reportFormat(params?.format)
       const response = await api.get('/export/trial-balance', {
         params: { ...params, format },
@@ -58,7 +58,7 @@ export function useExportTrialBalance() {
  */
 export function useExportBalanceSheet() {
   return useMutation({
-    mutationFn: async (params?: { date?: string; format?: string; journal_id?: string }) => {
+    mutationFn: async (params?: { date?: string; format?: string; journal_id?: string; posted_only?: boolean }) => {
       const format = reportFormat(params?.format)
       const response = await api.get('/export/balance-sheet', {
         params: { ...params, format },
@@ -76,7 +76,7 @@ export function useExportBalanceSheet() {
  */
 export function useExportIncomeStatement() {
   return useMutation({
-    mutationFn: async (params?: { start_date?: string; end_date?: string; format?: string; journal_id?: string }) => {
+    mutationFn: async (params?: { start_date?: string; end_date?: string; format?: string; journal_id?: string; posted_only?: boolean }) => {
       const format = reportFormat(params?.format)
       const response = await api.get('/export/income-statement', {
         params: { ...params, format },

--- a/src/api/useExports.ts
+++ b/src/api/useExports.ts
@@ -5,13 +5,25 @@ import { api } from './client'
 // Shared download helper
 // ─────────────────────────────────────────────────────────────
 
-function downloadBlob(data: Blob, filename: string) {
-  const blob = new Blob([data], { type: 'text/csv' })
+function reportFormat(format?: string): 'csv' | 'xlsx' | 'pdf' {
+  if (format === 'pdf') return 'pdf'
+  if (format === 'xlsx' || format === 'excel') return 'xlsx'
+  return 'csv'
+}
+
+function downloadBlob(data: Blob, filename: string, mime = 'text/csv') {
+  const blob = new Blob([data], { type: mime || data.type || 'application/octet-stream' })
   const link = document.createElement('a')
   link.href = URL.createObjectURL(blob)
   link.download = filename
   link.click()
   URL.revokeObjectURL(link.href)
+}
+
+function mimeFor(format: 'csv' | 'xlsx' | 'pdf'): string {
+  if (format === 'pdf') return 'application/pdf'
+  if (format === 'xlsx') return 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+  return 'text/csv'
 }
 
 function today() {
@@ -28,12 +40,13 @@ function today() {
  */
 export function useExportTrialBalance() {
   return useMutation({
-    mutationFn: async (params?: { date?: string }) => {
+    mutationFn: async (params?: { date?: string; format?: string }) => {
+      const format = reportFormat(params?.format)
       const response = await api.get('/export/trial-balance', {
-        params: { format: 'csv', ...params },
+        params: { ...params, format },
         responseType: 'blob',
       })
-      downloadBlob(response.data, `trial-balance-${params?.date || today()}.csv`)
+      downloadBlob(response.data, `trial-balance-${params?.date || today()}.${format}`, mimeFor(format))
       return true
     },
   })
@@ -45,12 +58,13 @@ export function useExportTrialBalance() {
  */
 export function useExportBalanceSheet() {
   return useMutation({
-    mutationFn: async (params?: { date?: string }) => {
+    mutationFn: async (params?: { date?: string; format?: string; journal_id?: string }) => {
+      const format = reportFormat(params?.format)
       const response = await api.get('/export/balance-sheet', {
-        params: { format: 'csv', ...params },
+        params: { ...params, format },
         responseType: 'blob',
       })
-      downloadBlob(response.data, `balance-sheet-${params?.date || today()}.csv`)
+      downloadBlob(response.data, `balance-sheet-${params?.date || today()}.${format}`, mimeFor(format))
       return true
     },
   })
@@ -62,12 +76,13 @@ export function useExportBalanceSheet() {
  */
 export function useExportIncomeStatement() {
   return useMutation({
-    mutationFn: async (params?: { start_date?: string; end_date?: string }) => {
+    mutationFn: async (params?: { start_date?: string; end_date?: string; format?: string; journal_id?: string }) => {
+      const format = reportFormat(params?.format)
       const response = await api.get('/export/income-statement', {
-        params: { format: 'csv', ...params },
+        params: { ...params, format },
         responseType: 'blob',
       })
-      downloadBlob(response.data, `income-statement-${params?.start_date || today()}.csv`)
+      downloadBlob(response.data, `income-statement-${params?.start_date || today()}.${format}`, mimeFor(format))
       return true
     },
   })
@@ -85,12 +100,15 @@ export function useExportGeneralLedger() {
       end_date?: string
       journal_id?: string
       analytic_account_id?: string
+      format?: string
+      posted_only?: boolean
     }) => {
+      const format = reportFormat(params?.format)
       const response = await api.get('/export/general-ledger', {
-        params: { format: 'csv', ...params },
+        params: { ...params, format },
         responseType: 'blob',
       })
-      downloadBlob(response.data, `general-ledger-${params?.start_date || today()}.csv`)
+      downloadBlob(response.data, `general-ledger-${params?.start_date || today()}.${format}`, mimeFor(format))
       return true
     },
   })
@@ -98,12 +116,13 @@ export function useExportGeneralLedger() {
 
 export function useExportCashFlow() {
   return useMutation({
-    mutationFn: async (params?: { start_date?: string; end_date?: string }) => {
+    mutationFn: async (params?: { start_date?: string; end_date?: string; format?: string; journal_id?: string }) => {
+      const format = reportFormat(params?.format)
       const response = await api.get('/export/cash-flow', {
-        params: { format: 'csv', ...params },
+        params: { ...params, format },
         responseType: 'blob',
       })
-      downloadBlob(response.data, `cash-flow-${params?.start_date || today()}.csv`)
+      downloadBlob(response.data, `cash-flow-${params?.start_date || today()}.${format}`, mimeFor(format))
       return true
     },
   })
@@ -111,12 +130,13 @@ export function useExportCashFlow() {
 
 export function useExportChangesInEquity() {
   return useMutation({
-    mutationFn: async (params?: { start_date?: string; end_date?: string }) => {
+    mutationFn: async (params?: { start_date?: string; end_date?: string; format?: string }) => {
+      const format = reportFormat(params?.format)
       const response = await api.get('/export/changes-in-equity', {
-        params: { format: 'csv', ...params },
+        params: { ...params, format },
         responseType: 'blob',
       })
-      downloadBlob(response.data, `changes-in-equity-${params?.start_date || today()}.csv`)
+      downloadBlob(response.data, `changes-in-equity-${params?.start_date || today()}.${format}`, mimeFor(format))
       return true
     },
   })
@@ -124,12 +144,13 @@ export function useExportChangesInEquity() {
 
 export function useExportDailyCashMovement() {
   return useMutation({
-    mutationFn: async (params?: { start_date?: string; end_date?: string }) => {
+    mutationFn: async (params?: { start_date?: string; end_date?: string; format?: string }) => {
+      const format = reportFormat(params?.format)
       const response = await api.get('/export/daily-cash-movement', {
-        params: { format: 'csv', ...params },
+        params: { ...params, format },
         responseType: 'blob',
       })
-      downloadBlob(response.data, `daily-cash-movement-${params?.start_date || today()}.csv`)
+      downloadBlob(response.data, `daily-cash-movement-${params?.start_date || today()}.${format}`, mimeFor(format))
       return true
     },
   })

--- a/src/api/useReports.ts
+++ b/src/api/useReports.ts
@@ -865,15 +865,17 @@ export function useTrialBalance(
 export function useBalanceSheet(
   asOfDate?: Ref<string | undefined>,
   compareTo?: Ref<string | undefined>,
-  journalId?: Ref<string | undefined>
+  journalId?: Ref<string | undefined>,
+  postedOnly?: Ref<boolean | undefined>
 ) {
   return useQuery({
-    queryKey: ['reports', 'balance-sheet', asOfDate, compareTo, journalId],
+    queryKey: ['reports', 'balance-sheet', asOfDate, compareTo, journalId, postedOnly],
     queryFn: async () => {
       const params: Record<string, string> = {}
       if (asOfDate?.value) params.as_of_date = asOfDate.value
       if (compareTo?.value) params.compare_to = compareTo.value
       if (journalId?.value) params.journal_id = journalId.value
+      if (postedOnly?.value === false) params.posted_only = '0'
       const response = await api.get<{ data: BalanceSheetReport & {
         current_period?: BalanceSheetReport
         variance?: BalanceSheetReport['variance']
@@ -896,16 +898,18 @@ export function useIncomeStatement(
   startDate?: Ref<string | undefined>,
   endDate?: Ref<string | undefined>,
   comparePreviousPeriod?: Ref<boolean>,
-  journalId?: Ref<string | undefined>
+  journalId?: Ref<string | undefined>,
+  postedOnly?: Ref<boolean | undefined>
 ) {
   return useQuery({
-    queryKey: ['reports', 'income-statement', startDate, endDate, comparePreviousPeriod, journalId],
+    queryKey: ['reports', 'income-statement', startDate, endDate, comparePreviousPeriod, journalId, postedOnly],
     queryFn: async () => {
       const params: Record<string, string> = {}
       if (startDate?.value) params.start_date = startDate.value
       if (endDate?.value) params.end_date = endDate.value
       if (comparePreviousPeriod?.value) params.compare_previous_period = '1'
       if (journalId?.value) params.journal_id = journalId.value
+      if (postedOnly?.value === false) params.posted_only = '0'
       const response = await api.get<{ data: IncomeStatementReport & {
         current_period?: IncomeStatementReport
         variance?: IncomeStatementReport['variance']

--- a/src/api/useReports.ts
+++ b/src/api/useReports.ts
@@ -845,14 +845,16 @@ export interface BankReconciliationReport {
 
 export function useTrialBalance(
   asOfDate?: Ref<string | undefined>,
-  journalId?: Ref<string | undefined>
+  journalId?: Ref<string | undefined>,
+  postedOnly?: Ref<boolean | undefined>
 ) {
   return useQuery({
-    queryKey: ['reports', 'trial-balance', asOfDate, journalId],
+    queryKey: ['reports', 'trial-balance', asOfDate, journalId, postedOnly],
     queryFn: async () => {
       const params: Record<string, string> = {}
       if (asOfDate?.value) params.as_of_date = asOfDate.value
       if (journalId?.value) params.journal_id = journalId.value
+      if (postedOnly?.value === false) params.posted_only = '0'
       const response = await api.get<{ data: TrialBalanceReport }>('/reports/trial-balance', { params })
       return response.data.data
     },
@@ -862,14 +864,16 @@ export function useTrialBalance(
 
 export function useBalanceSheet(
   asOfDate?: Ref<string | undefined>,
-  compareTo?: Ref<string | undefined>
+  compareTo?: Ref<string | undefined>,
+  journalId?: Ref<string | undefined>
 ) {
   return useQuery({
-    queryKey: ['reports', 'balance-sheet', asOfDate, compareTo],
+    queryKey: ['reports', 'balance-sheet', asOfDate, compareTo, journalId],
     queryFn: async () => {
       const params: Record<string, string> = {}
       if (asOfDate?.value) params.as_of_date = asOfDate.value
       if (compareTo?.value) params.compare_to = compareTo.value
+      if (journalId?.value) params.journal_id = journalId.value
       const response = await api.get<{ data: BalanceSheetReport & {
         current_period?: BalanceSheetReport
         variance?: BalanceSheetReport['variance']
@@ -891,15 +895,17 @@ export function useBalanceSheet(
 export function useIncomeStatement(
   startDate?: Ref<string | undefined>,
   endDate?: Ref<string | undefined>,
-  comparePreviousPeriod?: Ref<boolean>
+  comparePreviousPeriod?: Ref<boolean>,
+  journalId?: Ref<string | undefined>
 ) {
   return useQuery({
-    queryKey: ['reports', 'income-statement', startDate, endDate, comparePreviousPeriod],
+    queryKey: ['reports', 'income-statement', startDate, endDate, comparePreviousPeriod, journalId],
     queryFn: async () => {
       const params: Record<string, string> = {}
       if (startDate?.value) params.start_date = startDate.value
       if (endDate?.value) params.end_date = endDate.value
       if (comparePreviousPeriod?.value) params.compare_previous_period = '1'
+      if (journalId?.value) params.journal_id = journalId.value
       const response = await api.get<{ data: IncomeStatementReport & {
         current_period?: IncomeStatementReport
         variance?: IncomeStatementReport['variance']
@@ -921,15 +927,17 @@ export function useIncomeStatement(
 export function useCashFlow(
   startDate?: Ref<string | undefined>,
   endDate?: Ref<string | undefined>,
-  comparePreviousPeriod?: Ref<boolean>
+  comparePreviousPeriod?: Ref<boolean>,
+  journalId?: Ref<string | undefined>
 ) {
   return useQuery({
-    queryKey: ['reports', 'cash-flow', startDate, endDate, comparePreviousPeriod],
+    queryKey: ['reports', 'cash-flow', startDate, endDate, comparePreviousPeriod, journalId],
     queryFn: async () => {
       const params: Record<string, string> = {}
       if (startDate?.value) params.start_date = startDate.value
       if (endDate?.value) params.end_date = endDate.value
       if (comparePreviousPeriod?.value) params.compare_previous_period = '1'
+      if (journalId?.value) params.journal_id = journalId.value
       const response = await api.get<{ data: CashFlowReport & {
         current_period?: CashFlowReport
         variance?: CashFlowReport['variance']
@@ -976,16 +984,18 @@ export function useGeneralLedger(
   startDate?: Ref<string | undefined>,
   endDate?: Ref<string | undefined>,
   journalId?: Ref<string | undefined>,
-  analyticAccountId?: Ref<string | undefined>
+  analyticAccountId?: Ref<string | undefined>,
+  postedOnly?: Ref<boolean | undefined>
 ) {
   return useQuery({
-    queryKey: ['reports', 'general-ledger', startDate, endDate, journalId, analyticAccountId],
+    queryKey: ['reports', 'general-ledger', startDate, endDate, journalId, analyticAccountId, postedOnly],
     queryFn: async () => {
       const params: Record<string, string> = {}
       if (startDate?.value) params.start_date = startDate.value
       if (endDate?.value) params.end_date = endDate.value
       if (journalId?.value) params.journal_id = journalId.value
       if (analyticAccountId?.value) params.analytic_account_id = analyticAccountId.value
+      if (postedOnly?.value === false) params.posted_only = '0'
       const response = await api.get<{ data: GeneralLedgerReport }>('/reports/general-ledger', { params })
       return response.data.data
     },

--- a/src/components/ui/ExportButton.vue
+++ b/src/components/ui/ExportButton.vue
@@ -21,12 +21,12 @@ withDefaults(defineProps<Props>(), {
 })
 
 const emit = defineEmits<{
-  export: [format: 'excel' | 'csv']
+  export: [format: 'excel' | 'csv' | 'pdf']
 }>()
 
 const isOpen = ref(false)
 
-function handleExport(format: 'excel' | 'csv') {
+function handleExport(format: 'excel' | 'csv' | 'pdf') {
   emit('export', format)
   isOpen.value = false
 }
@@ -118,6 +118,13 @@ onUnmounted(() => {
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
           </svg>
           CSV (.csv)
+        </button>
+        <button
+          type="button"
+          class="w-full flex items-center gap-2 px-4 py-2 text-sm text-slate-700 dark:text-slate-200 hover:bg-slate-50 dark:hover:bg-slate-700 transition-colors"
+          @click="handleExport('pdf')"
+        >
+          PDF (.pdf)
         </button>
       </div>
     </Transition>

--- a/src/pages/reports/BalanceSheetPage.vue
+++ b/src/pages/reports/BalanceSheetPage.vue
@@ -3,22 +3,35 @@ import { ref, computed } from 'vue'
 import { useRouter } from 'vue-router'
 import { useBalanceSheet } from '@/api/useReports'
 import { useExportBalanceSheet } from '@/api/useExports'
-import { Button, Input, Card, Badge, ExportButton } from '@/components/ui'
+import { useJournalsLookup, journalTypeLabel } from '@/api/useJournals'
+import { Button, Input, Card, Badge, ExportButton, Select } from '@/components/ui'
 import { formatCurrency, toLocalISODate } from '@/utils/format'
 
 const router = useRouter()
 
 const asOfDate = ref(toLocalISODate())
 const compareTo = ref('')
+const journalId = ref('')
 const asOfDateRef = computed(() => asOfDate.value)
 const compareToRef = computed(() => compareTo.value || undefined)
+const journalIdRef = computed(() => journalId.value || undefined)
 
-const { data: report, isLoading, error } = useBalanceSheet(asOfDateRef, compareToRef)
+const { data: journals } = useJournalsLookup()
+const journalOptions = computed(() => {
+  const options = [{ value: '', label: 'All Journals' }]
+  if (!journals.value) return options
+  return options.concat(journals.value.map((journal) => ({
+    value: String(journal.id),
+    label: `${journal.name} (${journalTypeLabel(journal.type)})`,
+  })))
+})
+
+const { data: report, isLoading, error } = useBalanceSheet(asOfDateRef, compareToRef, journalIdRef)
 
 const exportMutation = useExportBalanceSheet()
 
-function handleExport() {
-  exportMutation.mutate({ date: asOfDate.value || undefined })
+function handleExport(format: 'excel' | 'csv' | 'pdf' = 'csv') {
+  exportMutation.mutate({ date: asOfDate.value || undefined, format, journal_id: journalId.value || undefined })
 }
 
 function formatAmount(amount: number): string {
@@ -35,7 +48,7 @@ function formatAmount(amount: number): string {
         <p class="text-slate-500 dark:text-slate-400">Laporan Posisi Keuangan - Assets, liabilities, and equity</p>
       </div>
       <div class="flex gap-2">
-        <ExportButton :show-format-options="false" :loading="exportMutation.isPending.value" @export="handleExport" />
+        <ExportButton :loading="exportMutation.isPending.value" @export="handleExport" />
         <Button variant="ghost" @click="router.push('/reports')">Back to Reports</Button>
       </div>
     </div>
@@ -50,6 +63,10 @@ function formatAmount(amount: number): string {
         <div>
           <label class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">Compare to</label>
           <Input v-model="compareTo" type="date" class="w-40" />
+        </div>
+        <div class="min-w-[200px]">
+          <label class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">Journal</label>
+          <Select v-model="journalId" :options="journalOptions" placeholder="All Journals" />
         </div>
         <div class="flex gap-2">
           <Button

--- a/src/pages/reports/BalanceSheetPage.vue
+++ b/src/pages/reports/BalanceSheetPage.vue
@@ -12,9 +12,11 @@ const router = useRouter()
 const asOfDate = ref(toLocalISODate())
 const compareTo = ref('')
 const journalId = ref('')
+const postedOnly = ref(true)
 const asOfDateRef = computed(() => asOfDate.value)
 const compareToRef = computed(() => compareTo.value || undefined)
 const journalIdRef = computed(() => journalId.value || undefined)
+const postedOnlyRef = computed(() => postedOnly.value)
 
 const { data: journals } = useJournalsLookup()
 const journalOptions = computed(() => {
@@ -26,12 +28,17 @@ const journalOptions = computed(() => {
   })))
 })
 
-const { data: report, isLoading, error } = useBalanceSheet(asOfDateRef, compareToRef, journalIdRef)
+const { data: report, isLoading, error } = useBalanceSheet(asOfDateRef, compareToRef, journalIdRef, postedOnlyRef)
 
 const exportMutation = useExportBalanceSheet()
 
 function handleExport(format: 'excel' | 'csv' | 'pdf' = 'csv') {
-  exportMutation.mutate({ date: asOfDate.value || undefined, format, journal_id: journalId.value || undefined })
+  exportMutation.mutate({
+    date: asOfDate.value || undefined,
+    format,
+    journal_id: journalId.value || undefined,
+    posted_only: postedOnly.value,
+  })
 }
 
 function formatAmount(amount: number): string {
@@ -68,6 +75,10 @@ function formatAmount(amount: number): string {
           <label class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">Journal</label>
           <Select v-model="journalId" :options="journalOptions" placeholder="All Journals" />
         </div>
+        <label class="flex items-center gap-2 text-sm text-slate-700 dark:text-slate-300 pb-2">
+          <input v-model="postedOnly" type="checkbox" data-testid="bs-posted-only" />
+          Posted Entries
+        </label>
         <div class="flex gap-2">
           <Button
             variant="secondary"

--- a/src/pages/reports/CashFlowPage.vue
+++ b/src/pages/reports/CashFlowPage.vue
@@ -3,7 +3,8 @@ import { ref, computed } from 'vue'
 import { useRouter } from 'vue-router'
 import { useCashFlow } from '@/api/useReports'
 import { useExportCashFlow } from '@/api/useExports'
-import { Button, Input, Card, ExportButton } from '@/components/ui'
+import { useJournalsLookup, journalTypeLabel } from '@/api/useJournals'
+import { Button, Input, Card, ExportButton, Select } from '@/components/ui'
 import { formatCurrency, toLocalISODate } from '@/utils/format'
 
 const router = useRouter()
@@ -11,19 +12,33 @@ const router = useRouter()
 const startDate = ref(toLocalISODate(new Date(new Date().getFullYear(), new Date().getMonth(), 1)))
 const endDate = ref(toLocalISODate())
 const comparePreviousPeriod = ref(false)
+const journalId = ref('')
 
 const startDateRef = computed(() => startDate.value)
 const endDateRef = computed(() => endDate.value)
 const comparePreviousPeriodRef = computed(() => comparePreviousPeriod.value)
+const journalIdRef = computed(() => journalId.value || undefined)
 
-const { data: report, isLoading, error } = useCashFlow(startDateRef, endDateRef, comparePreviousPeriodRef)
+const { data: journals } = useJournalsLookup()
+const journalOptions = computed(() => {
+  const options = [{ value: '', label: 'All Journals' }]
+  if (!journals.value) return options
+  return options.concat(journals.value.map((journal) => ({
+    value: String(journal.id),
+    label: `${journal.name} (${journalTypeLabel(journal.type)})`,
+  })))
+})
+
+const { data: report, isLoading, error } = useCashFlow(startDateRef, endDateRef, comparePreviousPeriodRef, journalIdRef)
 
 const exportMutation = useExportCashFlow()
 
-function handleExport() {
+function handleExport(format: 'excel' | 'csv' | 'pdf' = 'csv') {
   exportMutation.mutate({
     start_date: startDate.value || undefined,
     end_date: endDate.value || undefined,
+    format,
+    journal_id: journalId.value || undefined,
   })
 }
 
@@ -41,7 +56,7 @@ function formatAmount(amount: number): string {
         <p class="text-slate-500 dark:text-slate-400">Laporan Arus Kas - Cash movements by activity</p>
       </div>
       <div class="flex gap-2">
-        <ExportButton :show-format-options="false" :loading="exportMutation.isPending.value" @export="handleExport" />
+        <ExportButton :loading="exportMutation.isPending.value" @export="handleExport" />
         <Button variant="ghost" @click="router.push('/reports')">Back to Reports</Button>
       </div>
     </div>
@@ -56,6 +71,10 @@ function formatAmount(amount: number): string {
         <div>
           <label class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">End Date</label>
           <Input v-model="endDate" type="date" class="w-40" />
+        </div>
+        <div class="min-w-[200px]">
+          <label class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">Journal</label>
+          <Select v-model="journalId" :options="journalOptions" placeholder="All Journals" />
         </div>
         <div class="flex gap-2">
           <Button

--- a/src/pages/reports/ChangesInEquityPage.vue
+++ b/src/pages/reports/ChangesInEquityPage.vue
@@ -8,7 +8,7 @@
         </h1>
         <p class="text-sm text-muted-foreground">Laporan Perubahan Ekuitas</p>
       </div>
-      <ExportButton :show-format-options="false" :loading="exportMutation.isPending.value" @export="handleExport" />
+      <ExportButton :loading="exportMutation.isPending.value" @export="handleExport" />
     </div>
 
     <!-- Filters -->
@@ -226,10 +226,11 @@ import { formatCurrency, toLocalISODate } from '@/utils/format'
 
 const exportMutation = useExportChangesInEquity()
 
-function handleExport() {
+function handleExport(format: 'excel' | 'csv' | 'pdf' = 'csv') {
   exportMutation.mutate({
     start_date: startDate.value || undefined,
     end_date: endDate.value || undefined,
+    format,
   })
 }
 

--- a/src/pages/reports/DailyCashMovementPage.vue
+++ b/src/pages/reports/DailyCashMovementPage.vue
@@ -6,7 +6,7 @@
         <h1 class="text-3xl font-bold text-slate-900 dark:text-slate-100">Daily Cash Movement</h1>
         <p class="text-muted-foreground">Mutasi Kas Harian</p>
       </div>
-      <ExportButton :show-format-options="false" :loading="exportMutation.isPending.value" @export="handleExport" />
+      <ExportButton :loading="exportMutation.isPending.value" @export="handleExport" />
     </div>
 
     <!-- Filter Card -->
@@ -180,10 +180,11 @@ const { data: report, isLoading, error } = useDailyCashMovement(startDateRef, en
 
 const exportMutation = useExportDailyCashMovement()
 
-function handleExport() {
+function handleExport(format: 'excel' | 'csv' | 'pdf' = 'csv') {
   exportMutation.mutate({
     start_date: startDate.value || undefined,
     end_date: endDate.value || undefined,
+    format,
   })
 }
 

--- a/src/pages/reports/GeneralLedgerPage.vue
+++ b/src/pages/reports/GeneralLedgerPage.vue
@@ -4,6 +4,7 @@ import { useRouter } from 'vue-router'
 import { useGeneralLedger } from '@/api/useReports'
 import { useExportGeneralLedger } from '@/api/useExports'
 import { useJournalsLookup, journalTypeLabel } from '@/api/useJournals'
+import { useAnalyticAccountsLookup } from '@/api/useAnalyticAccounts'
 import { Button, Input, Card, ExportButton, Select } from '@/components/ui'
 import { formatCurrency, formatDate } from '@/utils/format'
 import { ArrowLeft, ChevronDown, ChevronRight } from 'lucide-vue-next'
@@ -15,8 +16,10 @@ const startDate = ref('')
 const endDate = ref('')
 const journalId = ref('')
 const analyticAccountId = ref('')
+const postedOnly = ref(true)
 
 const { data: journals } = useJournalsLookup()
+const { data: analyticAccounts } = useAnalyticAccountsLookup()
 const journalOptions = computed(() => {
   const options = [{ value: '', label: 'All Journals' }]
   if (!journals.value) return options
@@ -31,12 +34,23 @@ const startDateComputed = computed(() => startDate.value)
 const endDateComputed = computed(() => endDate.value)
 const journalIdComputed = computed(() => journalId.value || undefined)
 const analyticAccountIdComputed = computed(() => analyticAccountId.value || undefined)
+const postedOnlyComputed = computed(() => postedOnly.value)
+
+const analyticOptions = computed(() => {
+  const options = [{ value: '', label: 'All analytics' }]
+  if (!analyticAccounts.value) return options
+  return options.concat(analyticAccounts.value.map((account) => ({
+    value: String(account.id),
+    label: `${account.code} · ${account.name}`,
+  })))
+})
 
 const { data: report, isLoading, isError, error } = useGeneralLedger(
   startDateComputed,
   endDateComputed,
   journalIdComputed,
-  analyticAccountIdComputed
+  analyticAccountIdComputed,
+  postedOnlyComputed
 )
 
 // Expanded accounts tracking
@@ -67,12 +81,14 @@ function setThisMonth() {
 
 const exportMutation = useExportGeneralLedger()
 
-function handleExport() {
+function handleExport(format: 'excel' | 'csv' | 'pdf' = 'csv') {
   exportMutation.mutate({
     start_date: startDate.value || undefined,
     end_date: endDate.value || undefined,
     journal_id: journalId.value || undefined,
     analytic_account_id: analyticAccountId.value || undefined,
+    format,
+    posted_only: postedOnly.value,
   })
 }
 
@@ -109,7 +125,7 @@ function setYearToDate() {
           Buku Besar - Detailed account transactions
         </p>
       </div>
-      <ExportButton :show-format-options="false" :loading="exportMutation.isPending.value" @export="handleExport" />
+      <ExportButton :loading="exportMutation.isPending.value" @export="handleExport" />
     </div>
 
     <!-- Filter Card -->
@@ -144,10 +160,14 @@ function setYearToDate() {
         </div>
         <div class="flex-1 min-w-[160px]">
           <label class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">
-            Analytic account ID
+            Analytic
           </label>
-          <Input v-model="analyticAccountId" type="number" min="1" placeholder="Optional" />
+          <Select v-model="analyticAccountId" :options="analyticOptions" placeholder="All analytics" />
         </div>
+        <label class="flex items-center gap-2 text-sm text-slate-700 dark:text-slate-300 pb-2">
+          <input v-model="postedOnly" type="checkbox" data-testid="gl-posted-only" />
+          Posted Entries
+        </label>
         <div class="flex gap-2">
           <Button
             variant="outline"

--- a/src/pages/reports/IncomeStatementPage.vue
+++ b/src/pages/reports/IncomeStatementPage.vue
@@ -14,11 +14,13 @@ const startDate = ref(toLocalISODate(new Date(new Date().getFullYear(), new Date
 const endDate = ref(toLocalISODate())
 const comparePreviousPeriod = ref(false)
 const journalId = ref('')
+const postedOnly = ref(true)
 
 const startDateRef = computed(() => startDate.value)
 const endDateRef = computed(() => endDate.value)
 const comparePreviousPeriodRef = computed(() => comparePreviousPeriod.value)
 const journalIdRef = computed(() => journalId.value || undefined)
+const postedOnlyRef = computed(() => postedOnly.value)
 
 const { data: journals } = useJournalsLookup()
 const journalOptions = computed(() => {
@@ -30,12 +32,18 @@ const journalOptions = computed(() => {
   })))
 })
 
-const { data: report, isLoading, error } = useIncomeStatement(startDateRef, endDateRef, comparePreviousPeriodRef, journalIdRef)
+const { data: report, isLoading, error } = useIncomeStatement(startDateRef, endDateRef, comparePreviousPeriodRef, journalIdRef, postedOnlyRef)
 
 const exportMutation = useExportIncomeStatement()
 
 function handleExport(format: 'excel' | 'csv' | 'pdf' = 'csv') {
-  exportMutation.mutate({ start_date: startDate.value || undefined, end_date: endDate.value || undefined, format, journal_id: journalId.value || undefined })
+  exportMutation.mutate({
+    start_date: startDate.value || undefined,
+    end_date: endDate.value || undefined,
+    format,
+    journal_id: journalId.value || undefined,
+    posted_only: postedOnly.value,
+  })
 }
 
 function formatAmount(amount: number): string {
@@ -72,6 +80,10 @@ function formatAmount(amount: number): string {
           <label class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">Journal</label>
           <Select v-model="journalId" :options="journalOptions" placeholder="All Journals" />
         </div>
+        <label class="flex items-center gap-2 text-sm text-slate-700 dark:text-slate-300 pb-2">
+          <input v-model="postedOnly" type="checkbox" data-testid="is-posted-only" />
+          Posted Entries
+        </label>
         <div class="flex gap-2">
           <Button
             variant="secondary"

--- a/src/pages/reports/IncomeStatementPage.vue
+++ b/src/pages/reports/IncomeStatementPage.vue
@@ -3,7 +3,8 @@ import { ref, computed } from 'vue'
 import { useRouter } from 'vue-router'
 import { useIncomeStatement } from '@/api/useReports'
 import { useExportIncomeStatement } from '@/api/useExports'
-import { Button, Input, Card, ExportButton } from '@/components/ui'
+import { useJournalsLookup, journalTypeLabel } from '@/api/useJournals'
+import { Button, Input, Card, ExportButton, Select } from '@/components/ui'
 import { formatCurrency, toLocalISODate } from '@/utils/format'
 
 const router = useRouter()
@@ -12,17 +13,29 @@ const router = useRouter()
 const startDate = ref(toLocalISODate(new Date(new Date().getFullYear(), new Date().getMonth(), 1)))
 const endDate = ref(toLocalISODate())
 const comparePreviousPeriod = ref(false)
+const journalId = ref('')
 
 const startDateRef = computed(() => startDate.value)
 const endDateRef = computed(() => endDate.value)
 const comparePreviousPeriodRef = computed(() => comparePreviousPeriod.value)
+const journalIdRef = computed(() => journalId.value || undefined)
 
-const { data: report, isLoading, error } = useIncomeStatement(startDateRef, endDateRef, comparePreviousPeriodRef)
+const { data: journals } = useJournalsLookup()
+const journalOptions = computed(() => {
+  const options = [{ value: '', label: 'All Journals' }]
+  if (!journals.value) return options
+  return options.concat(journals.value.map((journal) => ({
+    value: String(journal.id),
+    label: `${journal.name} (${journalTypeLabel(journal.type)})`,
+  })))
+})
+
+const { data: report, isLoading, error } = useIncomeStatement(startDateRef, endDateRef, comparePreviousPeriodRef, journalIdRef)
 
 const exportMutation = useExportIncomeStatement()
 
-function handleExport() {
-  exportMutation.mutate({ start_date: startDate.value || undefined, end_date: endDate.value || undefined })
+function handleExport(format: 'excel' | 'csv' | 'pdf' = 'csv') {
+  exportMutation.mutate({ start_date: startDate.value || undefined, end_date: endDate.value || undefined, format, journal_id: journalId.value || undefined })
 }
 
 function formatAmount(amount: number): string {
@@ -39,7 +52,7 @@ function formatAmount(amount: number): string {
         <p class="text-slate-500 dark:text-slate-400">Laporan Laba Rugi - Revenue and expenses for the period</p>
       </div>
       <div class="flex gap-2">
-        <ExportButton :show-format-options="false" :loading="exportMutation.isPending.value" @export="handleExport" />
+        <ExportButton :loading="exportMutation.isPending.value" @export="handleExport" />
         <Button variant="ghost" @click="router.push('/reports')">Back to Reports</Button>
       </div>
     </div>
@@ -54,6 +67,10 @@ function formatAmount(amount: number): string {
         <div>
           <label class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">End Date</label>
           <Input v-model="endDate" type="date" class="w-40" />
+        </div>
+        <div class="min-w-[200px]">
+          <label class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">Journal</label>
+          <Select v-model="journalId" :options="journalOptions" placeholder="All Journals" />
         </div>
         <div class="flex gap-2">
           <Button

--- a/src/pages/reports/TrialBalancePage.vue
+++ b/src/pages/reports/TrialBalancePage.vue
@@ -11,8 +11,10 @@ const router = useRouter()
 
 const asOfDate = ref(toLocalISODate())
 const journalId = ref('')
+const postedOnly = ref(true)
 const asOfDateRef = computed(() => asOfDate.value)
 const journalIdRef = computed(() => journalId.value || undefined)
+const postedOnlyRef = computed(() => postedOnly.value)
 
 const { data: journals } = useJournalsLookup()
 const journalOptions = computed(() => {
@@ -24,12 +26,12 @@ const journalOptions = computed(() => {
   })))
 })
 
-const { data: report, isLoading, error } = useTrialBalance(asOfDateRef, journalIdRef)
+const { data: report, isLoading, error } = useTrialBalance(asOfDateRef, journalIdRef, postedOnlyRef)
 
 const exportMutation = useExportTrialBalance()
 
-function handleExport() {
-  exportMutation.mutate({ date: asOfDate.value || undefined })
+function handleExport(format: 'excel' | 'csv' | 'pdf' = 'csv') {
+  exportMutation.mutate({ date: asOfDate.value || undefined, format })
 }
 
 function getAccountTypeLabel(type: string): string {
@@ -63,7 +65,7 @@ function getAccountTypeColor(type: string): string {
         <p class="text-slate-500 dark:text-slate-400">Neraca Saldo - Summary of all account balances</p>
       </div>
       <div class="flex gap-2">
-        <ExportButton :show-format-options="false" :loading="exportMutation.isPending.value" @export="handleExport" />
+        <ExportButton :loading="exportMutation.isPending.value" @export="handleExport" />
         <Button variant="ghost" @click="router.push('/reports')">Back to Reports</Button>
       </div>
     </div>
@@ -79,6 +81,10 @@ function getAccountTypeColor(type: string): string {
           <label class="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-1">Journal</label>
           <Select v-model="journalId" :options="journalOptions" placeholder="All Journals" />
         </div>
+        <label class="flex items-center gap-2 text-sm text-slate-700 dark:text-slate-300 pb-2">
+          <input v-model="postedOnly" type="checkbox" data-testid="tb-posted-only" />
+          Posted Entries
+        </label>
         <div class="flex gap-2">
           <Button
             variant="secondary"

--- a/src/pages/reports/TrialBalancePage.vue
+++ b/src/pages/reports/TrialBalancePage.vue
@@ -31,7 +31,12 @@ const { data: report, isLoading, error } = useTrialBalance(asOfDateRef, journalI
 const exportMutation = useExportTrialBalance()
 
 function handleExport(format: 'excel' | 'csv' | 'pdf' = 'csv') {
-  exportMutation.mutate({ date: asOfDate.value || undefined, format })
+  exportMutation.mutate({
+    date: asOfDate.value || undefined,
+    format,
+    journal_id: journalId.value || undefined,
+    posted_only: postedOnly.value,
+  })
 }
 
 function getAccountTypeLabel(type: string): string {

--- a/src/pages/reports/__tests__/reportFiltersExports.test.ts
+++ b/src/pages/reports/__tests__/reportFiltersExports.test.ts
@@ -6,7 +6,7 @@ function pageSource(name: string): string {
   return readFileSync(resolve(__dirname, `../${name}`), 'utf8')
 }
 
-describe('report filters and exports (#37)', () => {
+describe('report filters and exports (#37 / #99)', () => {
   it.each([
     'CashFlowPage.vue',
     'ChangesInEquityPage.vue',
@@ -22,6 +22,20 @@ describe('report filters and exports (#37)', () => {
     expect(source).toContain('journalId')
     expect(source).toContain('analyticAccountId')
     expect(source).toContain('All Journals')
+    expect(source).toContain('useAnalyticAccountsLookup')
+    expect(source).toContain('Posted Entries')
+  })
+
+  it('adds journal filters to cash flow, balance sheet, and income statement', () => {
+    expect(pageSource('CashFlowPage.vue')).toContain('journalId')
+    expect(pageSource('BalanceSheetPage.vue')).toContain('journalId')
+    expect(pageSource('IncomeStatementPage.vue')).toContain('journalId')
+  })
+
+  it('offers pdf and xlsx export on core financial reports', () => {
+    expect(pageSource('CashFlowPage.vue')).not.toContain('show-format-options="false"')
+    expect(pageSource('BalanceSheetPage.vue')).not.toContain('show-format-options="false"')
+    expect(pageSource('GeneralLedgerPage.vue')).not.toContain('show-format-options="false"')
   })
 
   it('shows Invoice Date, Due Date, and Matching on partner ledger lines (#74)', () => {

--- a/src/pages/reports/__tests__/reportFiltersExports.test.ts
+++ b/src/pages/reports/__tests__/reportFiltersExports.test.ts
@@ -32,6 +32,13 @@ describe('report filters and exports (#37 / #99)', () => {
     expect(pageSource('IncomeStatementPage.vue')).toContain('journalId')
   })
 
+  it('exports trial balance with journal and posted filters and shows Posted Entries on BS/IS', () => {
+    expect(pageSource('TrialBalancePage.vue')).toContain('posted_only: postedOnly.value')
+    expect(pageSource('TrialBalancePage.vue')).toContain('journal_id: journalId.value')
+    expect(pageSource('BalanceSheetPage.vue')).toContain('Posted Entries')
+    expect(pageSource('IncomeStatementPage.vue')).toContain('Posted Entries')
+  })
+
   it('offers pdf and xlsx export on core financial reports', () => {
     expect(pageSource('CashFlowPage.vue')).not.toContain('show-format-options="false"')
     expect(pageSource('BalanceSheetPage.vue')).not.toContain('show-format-options="false"')


### PR DESCRIPTION
## Summary
- Export dropdown includes Excel, CSV, and PDF on core financial reports.
- Journal filter on Balance Sheet, Income Statement, and Cash Flow.
- GL analytic account picker (not a numeric ID) plus Posted Entries toggle.

Companion to satriyop/enter365#105. Related to satriyop/enter365#99.

## Test plan
- [ ] Vitest reportFiltersExports + ExportButton