### PR TITLE
feat(bills): tax records on bill lines, inherit product purchase taxes (#101)

### DIFF
--- a/src/pages/bills/BillDetailPage.vue
+++ b/src/pages/bills/BillDetailPage.vue
@@ -9,6 +9,7 @@ import { useWarehousesLookup } from '@/api/useInventory'
 import { Button, Card, Badge, Modal, Input, Textarea, Select, FormField, useToast, ResponsiveTable, type ResponsiveColumn } from '@/components/ui'
 import { formatAnalyticDistributionLabel, useAnalyticAccountsLookup } from '@/api/useAnalyticAccounts'
 import { formatTaxTagLabel, useTaxTagsLookup } from '@/api/useTaxTags'
+import { useTaxRecords } from '@/api/useTaxRecords'
 import { formatCurrency, formatDate, toNumber } from '@/utils/format'
 import { FileText, RotateCcw, Repeat } from 'lucide-vue-next'
 import AttachmentCard from '@/components/AttachmentCard.vue'
@@ -22,6 +23,18 @@ const { data: bill, isLoading } = useBill(billId)
 const { data: purchaseOrders } = usePurchaseOrdersLookup()
 const { data: analyticAccounts } = useAnalyticAccountsLookup()
 const { data: taxTags } = useTaxTagsLookup()
+const { data: taxRecords } = useTaxRecords('purchase')
+
+function formatBillLineTaxes(item: { tax_record_ids?: number[] | null; tax_tag_ids?: number[] | null }): string {
+  const records = (item.tax_record_ids ?? [])
+    .map((id) => taxRecords.value?.find((tax) => tax.id === id))
+    .filter((tax): tax is NonNullable<typeof tax> => Boolean(tax))
+    .map((tax) => `${tax.name} (${tax.rate}%)`)
+    .join(', ')
+  const tags = formatTaxTagLabel(item.tax_tag_ids, taxTags.value)
+
+  return [records, tags].filter(Boolean).join(' · ')
+}
 
 // Mutations
 const postMutation = usePostBill()
@@ -447,7 +460,7 @@ const journalItemColumns: ResponsiveColumn[] = [
               </template>
               <template #cell-taxes="{ item }">
                 <span class="text-slate-900 dark:text-slate-100">
-                  {{ formatTaxTagLabel((item as { tax_tag_ids?: number[] | null }).tax_tag_ids, taxTags) || '-' }}
+                  {{ formatBillLineTaxes(item as { tax_record_ids?: number[] | null; tax_tag_ids?: number[] | null }) || '-' }}
                 </span>
               </template>
               <template #cell-quantity="{ item }">

--- a/src/pages/bills/BillFormPage.vue
+++ b/src/pages/bills/BillFormPage.vue
@@ -8,6 +8,8 @@ import { toNumber, CURRENCY_OPTIONS } from '@/utils/format'
 import { useAccountsLookup } from '@/api/useAccounts'
 import { analyticDistributionFromAccountId, analyticDistributionPrimaryId, useAnalyticAccountsLookup } from '@/api/useAnalyticAccounts'
 import { useContactsLookup } from '@/api/useContacts'
+import { useProductsLookup } from '@/api/useProducts'
+import { useTaxRecords } from '@/api/useTaxRecords'
 import { taxTagIdsFromTagId, taxTagIdsPrimaryId, useTaxTagsLookup } from '@/api/useTaxTags'
 import { billSchema, type BillFormData, type BillItemFormData } from '@/utils/validation'
 import { setServerErrors } from '@/composables/useValidatedForm'
@@ -36,6 +38,8 @@ const contactOptions = computed(() =>
 const { data: accounts, isLoading: accountsLoading } = useAccountsLookup()
 const { data: analyticAccounts, isLoading: analyticAccountsLoading } = useAnalyticAccountsLookup()
 const { data: taxTags, isLoading: taxTagsLoading } = useTaxTagsLookup()
+const { data: products } = useProductsLookup()
+const { data: purchaseTaxRecords } = useTaxRecords('purchase')
 
 const accountOptions = computed(() =>
   (accounts.value ?? []).map((account) => ({
@@ -55,9 +59,16 @@ const taxTagOptions = computed(() =>
     label: `${tag.code} - ${tag.name}`,
   })),
 )
+const productOptions = computed(() =>
+  (products.value ?? []).map((product) => ({
+    value: product.id,
+    label: `${product.sku} - ${product.name}`,
+  })),
+)
 
 function createEmptyItem(): BillItemFormData {
   return {
+    product_id: null,
     description: '',
     quantity: 1,
     unit: 'pcs',
@@ -67,6 +78,7 @@ function createEmptyItem(): BillItemFormData {
     expense_account_id: undefined as unknown as number,
     analytic_account_id: null,
     tax_tag_id: null,
+    tax_record_ids: [],
   }
 }
 
@@ -132,8 +144,11 @@ watch(existingBill, (bill) => {
               account_id?: number | null
               analytic_distribution?: { [key: string]: number } | null
               tax_tag_ids?: number[] | null
+              tax_record_ids?: number[] | null
+              product_id?: number | null
             }
             return {
+              product_id: row.product_id ? Number(row.product_id) : null,
               description: item.description,
               quantity: item.quantity,
               unit: item.unit,
@@ -143,6 +158,7 @@ watch(existingBill, (bill) => {
               expense_account_id: item.expense_account_id ?? row.account_id ?? (undefined as unknown as number),
               analytic_account_id: Number(analyticDistributionPrimaryId(row.analytic_distribution)) || null,
               tax_tag_id: Number(taxTagIdsPrimaryId(row.tax_tag_ids)) || null,
+              tax_record_ids: row.tax_record_ids ?? [],
             }
           })
         : [createEmptyItem()],
@@ -159,6 +175,40 @@ function handleRemoveItem(index: number) {
   if (itemFields.value.length > 1) {
     removeItem(index)
   }
+}
+
+function rateForTaxIds(ids: number[]): number {
+  return (purchaseTaxRecords.value ?? [])
+    .filter((tax) => ids.includes(tax.id))
+    .reduce((sum, tax) => sum + Number(tax.rate), 0)
+}
+
+function onProductSelect(index: number, productId: number | null) {
+  const item = form.items?.[index]
+  if (!item) return
+  item.product_id = productId
+  if (!productId || !products.value) return
+  const product = products.value.find((row) => Number(row.id) === productId)
+  if (!product) return
+  item.description = product.name
+  item.unit = product.unit
+  item.unit_price = Number(product.purchase_price) || Number(product.selling_price) || 0
+  const inherited = (product.purchase_taxes ?? []).map((tax) => tax.id)
+  item.tax_record_ids = inherited
+  item.tax_rate = inherited.length
+    ? (product.purchase_taxes ?? []).reduce((sum, tax) => sum + Number(tax.rate), 0)
+    : Number(product.tax_rate) || 0
+}
+
+function toggleLineTax(index: number, taxId: number) {
+  const item = form.items?.[index]
+  if (!item) return
+  const current = item.tax_record_ids ?? []
+  const next = current.includes(taxId)
+    ? current.filter((id) => id !== taxId)
+    : [...current, taxId]
+  item.tax_record_ids = next
+  item.tax_rate = next.length ? rateForTaxIds(next) : item.tax_rate
 }
 
 // Calculations
@@ -184,15 +234,17 @@ const onSubmit = handleSubmit(async (formValues) => {
   const itemsPayload = (formValues.items || [])
     .filter(item => item.description)
     .map(item => ({
+      product_id: item.product_id || undefined,
       description: item.description,
       quantity: item.quantity,
       unit: item.unit,
       unit_price: item.unit_price,
       discount_percent: item.discount_percent,
-      tax_rate: item.tax_rate,
+      tax_rate: (item.tax_record_ids?.length || !item.product_id) ? item.tax_rate : undefined,
       expense_account_id: item.expense_account_id,
       analytic_distribution: analyticDistributionFromAccountId(item.analytic_account_id),
       tax_tag_ids: taxTagIdsFromTagId(item.tax_tag_id),
+      tax_record_ids: item.tax_record_ids?.length ? item.tax_record_ids : undefined,
     }))
 
   const payload = {
@@ -299,9 +351,21 @@ const onSubmit = handleSubmit(async (formValues) => {
           <div v-for="(field, index) in itemFields" :key="field.key" class="space-y-2 pb-4 border-b border-slate-100 dark:border-slate-800 last:border-0">
             <div class="grid grid-cols-12 gap-2 items-end">
               <div class="col-span-4">
+                <label v-if="index === 0" class="block text-xs font-medium text-slate-500 dark:text-slate-400 mb-1">Product</label>
+                <Select
+                  v-model="field.value.product_id"
+                  :options="productOptions"
+                  placeholder="Optional product"
+                  :test-id="`bill-item-${index}-product`"
+                  @update:model-value="(value) => onProductSelect(index, value ? Number(value) : null)"
+                />
+              </div>
+              <div class="col-span-8">
                 <label v-if="index === 0" class="block text-xs font-medium text-slate-500 dark:text-slate-400 mb-1">Description</label>
                 <Input v-model="field.value.description" placeholder="Item description" :data-testid="`bill-item-${index}-description`" />
               </div>
+            </div>
+            <div class="grid grid-cols-12 gap-2 items-end">
               <div class="col-span-2">
                 <label v-if="index === 0" class="block text-xs font-medium text-slate-500 dark:text-slate-400 mb-1">Qty</label>
                 <Input v-model.number="field.value.quantity" type="number" min="1" :data-testid="`bill-item-${index}-quantity`" />
@@ -312,7 +376,26 @@ const onSubmit = handleSubmit(async (formValues) => {
               </div>
               <div class="col-span-2">
                 <label v-if="index === 0" class="block text-xs font-medium text-slate-500 dark:text-slate-400 mb-1">Tax %</label>
-                <Input v-model.number="field.value.tax_rate" type="number" min="0" max="100" />
+                <Input v-model.number="field.value.tax_rate" type="number" min="0" max="100" :data-testid="`bill-item-${index}-tax-rate`" />
+              </div>
+              <div class="col-span-4">
+                <label v-if="index === 0" class="block text-xs font-medium text-slate-500 dark:text-slate-400 mb-1">Taxes</label>
+                <div class="flex flex-wrap gap-2 min-h-9 items-center" :data-testid="`bill-item-${index}-tax-records`">
+                  <label
+                    v-for="tax in purchaseTaxRecords"
+                    :key="tax.id"
+                    class="flex items-center gap-1 text-xs text-slate-700 dark:text-slate-300"
+                  >
+                    <input
+                      type="checkbox"
+                      class="rounded border-slate-300 dark:border-slate-600"
+                      :checked="(field.value.tax_record_ids ?? []).includes(tax.id)"
+                      @change="toggleLineTax(index, tax.id)"
+                    />
+                    {{ tax.name }} ({{ tax.rate }}%)
+                  </label>
+                  <span v-if="!purchaseTaxRecords?.length" class="text-xs text-slate-400">No tax records</span>
+                </div>
               </div>
               <div class="col-span-1 flex justify-end">
                 <Button type="button" variant="ghost" size="sm" @click="handleRemoveItem(index)" :disabled="itemFields.length === 1">
@@ -342,7 +425,7 @@ const onSubmit = handleSubmit(async (formValues) => {
                 />
               </div>
               <div class="col-span-4">
-                <label v-if="index === 0" class="block text-xs font-medium text-slate-500 dark:text-slate-400 mb-1">Taxes</label>
+                <label v-if="index === 0" class="block text-xs font-medium text-slate-500 dark:text-slate-400 mb-1">Tax tags</label>
                 <Select
                   v-model="field.value.tax_tag_id"
                   :options="taxTagOptions"

--- a/src/pages/bills/BillFormPage.vue
+++ b/src/pages/bills/BillFormPage.vue
@@ -79,6 +79,7 @@ function createEmptyItem(): BillItemFormData {
     analytic_account_id: null,
     tax_tag_id: null,
     tax_record_ids: [],
+    taxes_manual: false,
   }
 }
 
@@ -159,6 +160,7 @@ watch(existingBill, (bill) => {
               analytic_account_id: Number(analyticDistributionPrimaryId(row.analytic_distribution)) || null,
               tax_tag_id: Number(taxTagIdsPrimaryId(row.tax_tag_ids)) || null,
               tax_record_ids: row.tax_record_ids ?? [],
+              taxes_manual: Array.isArray(row.tax_record_ids),
             }
           })
         : [createEmptyItem()],
@@ -195,6 +197,7 @@ function onProductSelect(index: number, productId: number | null) {
   item.unit_price = Number(product.purchase_price) || Number(product.selling_price) || 0
   const inherited = (product.purchase_taxes ?? []).map((tax) => tax.id)
   item.tax_record_ids = inherited
+  item.taxes_manual = false
   item.tax_rate = inherited.length
     ? (product.purchase_taxes ?? []).reduce((sum, tax) => sum + Number(tax.rate), 0)
     : Number(product.tax_rate) || 0
@@ -208,7 +211,8 @@ function toggleLineTax(index: number, taxId: number) {
     ? current.filter((id) => id !== taxId)
     : [...current, taxId]
   item.tax_record_ids = next
-  item.tax_rate = next.length ? rateForTaxIds(next) : item.tax_rate
+  item.taxes_manual = true
+  item.tax_rate = next.length ? rateForTaxIds(next) : 0
 }
 
 // Calculations
@@ -240,11 +244,15 @@ const onSubmit = handleSubmit(async (formValues) => {
       unit: item.unit,
       unit_price: item.unit_price,
       discount_percent: item.discount_percent,
-      tax_rate: (item.tax_record_ids?.length || !item.product_id) ? item.tax_rate : undefined,
+      tax_rate: item.taxes_manual
+        ? (item.tax_rate || 0)
+        : ((item.tax_record_ids?.length || !item.product_id) ? item.tax_rate : undefined),
       expense_account_id: item.expense_account_id,
       analytic_distribution: analyticDistributionFromAccountId(item.analytic_account_id),
       tax_tag_ids: taxTagIdsFromTagId(item.tax_tag_id),
-      tax_record_ids: item.tax_record_ids?.length ? item.tax_record_ids : undefined,
+      tax_record_ids: item.taxes_manual
+        ? (item.tax_record_ids ?? [])
+        : (item.tax_record_ids?.length ? item.tax_record_ids : undefined),
     }))
 
   const payload = {

--- a/src/pages/bills/__tests__/billLineTaxRecords.test.ts
+++ b/src/pages/bills/__tests__/billLineTaxRecords.test.ts
@@ -9,6 +9,7 @@ describe('bill line tax records (#101)', () => {
 
     expect(form).toContain('useTaxRecords')
     expect(form).toContain('tax_record_ids')
+    expect(form).toContain('taxes_manual')
     expect(form).toContain('onProductSelect')
     expect(form).toContain('purchase_taxes')
     expect(form).toContain('bill-item-${index}-tax-records')

--- a/src/pages/bills/__tests__/billLineTaxRecords.test.ts
+++ b/src/pages/bills/__tests__/billLineTaxRecords.test.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+describe('bill line tax records (#101)', () => {
+  it('picks tax records and inherits product purchase taxes', () => {
+    const form = readFileSync(resolve(__dirname, '../BillFormPage.vue'), 'utf8')
+    const validation = readFileSync(resolve(__dirname, '../../../utils/validation.ts'), 'utf8')
+
+    expect(form).toContain('useTaxRecords')
+    expect(form).toContain('tax_record_ids')
+    expect(form).toContain('onProductSelect')
+    expect(form).toContain('purchase_taxes')
+    expect(form).toContain('bill-item-${index}-tax-records')
+    expect(form).toContain('Tax tags')
+    expect(validation).toContain('tax_record_ids: z.array(z.number())')
+  })
+})

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -566,6 +566,7 @@ export const bomTemplateSchema = z.object({
  * Bill item schema
  */
 export const billItemSchema = z.object({
+  product_id: z.number().optional().nullable(),
   description: requiredString('Description').max(500),
   quantity: quantitySchema.default(1),
   unit: z.string().max(20).default('pcs'),
@@ -575,6 +576,7 @@ export const billItemSchema = z.object({
   expense_account_id: z.number({ required_error: 'Please select an account' }).positive('Please select an account'),
   analytic_account_id: z.number().optional().nullable(),
   tax_tag_id: z.number().optional().nullable(),
+  tax_record_ids: z.array(z.number()).optional().default([]),
 })
 
 /**

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -577,6 +577,7 @@ export const billItemSchema = z.object({
   analytic_account_id: z.number().optional().nullable(),
   tax_tag_id: z.number().optional().nullable(),
   tax_record_ids: z.array(z.number()).optional().default([]),
+  taxes_manual: z.boolean().optional().default(false),
 })
 
 /**


### PR DESCRIPTION
## Summary
- Bill form: product picker, purchase **Taxes** from tax master (`tax_record_ids`).
- Product pick inherits `purchase_taxes` and summed rate.
- Tax tags stay available for JE grids.

Companion to enter365 bill-line tax records (#101). Stacked on FE #66 / `feat/tax-record-master-crud`.

## Test plan
- [x] Vitest `billLineTaxRecords.test.ts`
- [ ] Retarget to `main` after FE #66 merges