### PR TITLE
feat(reports): render VAT journal_grids (#104)

### DIFF
--- a/src/api/useReports.ts
+++ b/src/api/useReports.ts
@@ -242,6 +242,16 @@ export interface PpnSummaryReport {
       tax_rate: number
       tax: number
     }>
+    journal_grids?: Array<{
+      date: string
+      entry_number: string
+      source_type: string | null
+      description: string
+      tag_code: string
+      applicability: string
+      side: 'input' | 'output' | string
+      amount: number
+    }>
     bills: Array<{
       date: string
       number: string

--- a/src/pages/reports/TaxSummaryPage.vue
+++ b/src/pages/reports/TaxSummaryPage.vue
@@ -49,7 +49,7 @@ function getNetClass(net: number): string {
     <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6">
       <div>
         <h1 class="text-2xl font-semibold text-slate-900 dark:text-slate-100">Tax Summary</h1>
-        <p class="text-slate-500 dark:text-slate-400">Ringkasan Pajak - Taxes collected and paid</p>
+        <p class="text-slate-500 dark:text-slate-400">Ringkasan Pajak - Taxes collected and paid. Monthly totals include journal tax-grid adjustments.</p>
       </div>
       <Button variant="ghost" @click="router.push('/reports')">Back to Reports</Button>
     </div>

--- a/src/pages/reports/VatReportPage.vue
+++ b/src/pages/reports/VatReportPage.vue
@@ -206,6 +206,42 @@ function formatAmount(amount: number): string {
           </div>
         </div>
       </Card>
+
+      <Card v-if="(summaryReport.details?.journal_grids ?? []).length > 0">
+        <h3 class="text-lg font-semibold text-slate-900 dark:text-slate-100 mb-1">Tax Grids</h3>
+        <p class="text-sm text-slate-500 dark:text-slate-400 mb-4">
+          Journal item tax tags (misc, reversals). Credit notes reduce the original side.
+        </p>
+        <div class="overflow-x-auto">
+          <table class="w-full text-sm">
+            <thead class="bg-slate-50 dark:bg-slate-800">
+              <tr>
+                <th class="text-left px-4 py-3 font-medium text-slate-700 dark:text-slate-300">Date</th>
+                <th class="text-left px-4 py-3 font-medium text-slate-700 dark:text-slate-300">Entry</th>
+                <th class="text-left px-4 py-3 font-medium text-slate-700 dark:text-slate-300">Tag</th>
+                <th class="text-left px-4 py-3 font-medium text-slate-700 dark:text-slate-300">Side</th>
+                <th class="text-right px-4 py-3 font-medium text-slate-700 dark:text-slate-300">Amount</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-slate-100 dark:divide-slate-700">
+              <tr
+                v-for="(grid, index) in summaryReport.details.journal_grids"
+                :key="`${grid.entry_number}-${grid.tag_code}-${index}`"
+              >
+                <td class="px-4 py-3 text-slate-900 dark:text-slate-100">{{ grid.date }}</td>
+                <td class="px-4 py-3 font-mono text-slate-700 dark:text-slate-300">{{ grid.entry_number }}</td>
+                <td class="px-4 py-3 text-slate-700 dark:text-slate-300">{{ grid.tag_code }}</td>
+                <td class="px-4 py-3 capitalize" :class="grid.side === 'output' ? 'text-red-600 dark:text-red-400' : 'text-green-600 dark:text-green-400'">
+                  {{ grid.side }}
+                </td>
+                <td class="text-right px-4 py-3 font-mono" :class="grid.amount < 0 ? 'text-slate-500' : ''">
+                  {{ formatAmount(grid.amount) }}
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </Card>
     </div>
 
     <!-- Monthly View -->

--- a/src/pages/reports/__tests__/reportFiltersExports.test.ts
+++ b/src/pages/reports/__tests__/reportFiltersExports.test.ts
@@ -39,6 +39,16 @@ describe('report filters and exports (#37 / #99)', () => {
     expect(pageSource('IncomeStatementPage.vue')).toContain('Posted Entries')
   })
 
+  it('renders VAT journal_grids on the period summary (#104)', () => {
+    const page = pageSource('VatReportPage.vue')
+    const summary = pageSource('TaxSummaryPage.vue')
+    const reports = readFileSync(resolve(__dirname, '../../../api/useReports.ts'), 'utf8')
+    expect(reports).toContain('journal_grids')
+    expect(page).toContain('journal_grids')
+    expect(page).toContain('Tax Grids')
+    expect(summary).toContain('journal tax-grid')
+  })
+
   it('exports general ledger without requiring a single account_id (#109)', () => {
     const page = pageSource('GeneralLedgerPage.vue')
     const exports = readFileSync(resolve(__dirname, '../../../api/useExports.ts'), 'utf8')


### PR DESCRIPTION
## Summary
SPA VAT period summary now types and renders `details.journal_grids` (misc/reversal tax tags). Tax Summary monthly page notes that month totals already include those grids.

Companion to enter365 VAT grids + reversal classification (#104).

## Test plan (reviewer)
```bash
npx vitest run src/pages/reports/__tests__/reportFiltersExports.test.ts
```

Expect the `#104` case: `useReports.ts` and `VatReportPage.vue` contain `journal_grids` and a **Tax Grids** heading.