### PR TITLE
feat(tax): Invoice vs Refund distribution labels (#113)

### DIFF
--- a/src/pages/accounting/tax-records/TaxRecordFormPage.vue
+++ b/src/pages/accounting/tax-records/TaxRecordFormPage.vue
@@ -106,13 +106,13 @@ async function handleSubmit() {
         <Select
           :model-value="invoiceAccountId"
           :options="accountOptions"
-          placeholder="Invoice account"
+          placeholder="Distribution for Invoices (bills & invoices)"
           @update:model-value="(v) => { invoiceAccountId = v ? String(v) : '' }"
         />
         <Select
           :model-value="refundAccountId"
           :options="accountOptions"
-          placeholder="Refund account"
+          placeholder="Distribution for Refunds (credit notes)"
           @update:model-value="(v) => { refundAccountId = v ? String(v) : '' }"
         />
         <Select

--- a/src/pages/accounting/tax-records/__tests__/taxRecords.test.ts
+++ b/src/pages/accounting/tax-records/__tests__/taxRecords.test.ts
@@ -14,6 +14,8 @@ describe('tax records admin (#100)', () => {
     expect(list).toContain('New Tax')
     expect(form).toContain('invoice_account_id')
     expect(form).toContain('refund_account_id')
+    expect(form).toContain('Distribution for Invoices')
+    expect(form).toContain('Distribution for Refunds')
     expect(form).toContain('tax_tag_id')
     expect(form).toContain('computation')
     expect(form).toContain('is_active')


### PR DESCRIPTION
## Summary
Tax record form placeholders now match Odoo: Invoice distribution is for bills & invoices; Refund distribution is for credit notes.

Companion to enter365 #113.

## Test plan (reviewer)
```bash
npx vitest run src/pages/accounting/tax-records/__tests__/taxRecords.test.ts
```