### PR TITLE
fix(dates): fiscal period list dates match edit form (#123)

### DIFF
--- a/src/api/__tests__/fiscalPeriodDates.test.ts
+++ b/src/api/__tests__/fiscalPeriodDates.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { formatPeriodRange, isDateInPeriod } from '../useFiscalPeriods'
+import type { FiscalPeriod } from '../useFiscalPeriods'
+
+function period(start_date: string, end_date: string): FiscalPeriod {
+  return {
+    start_date,
+    end_date,
+  } as FiscalPeriod
+}
+
+describe('fiscal period calendar dates (#123)', () => {
+  it('formats 1 Jan–31 Dec without shifting to the previous day', () => {
+    const range = formatPeriodRange(period('2026-01-01', '2026-12-31'))
+    expect(range).toContain('2026')
+    expect(range.toLowerCase()).toContain('jan')
+    expect(range.toLowerCase()).toContain('des')
+    expect(range).not.toMatch(/2025/)
+  })
+
+  it('includes the stored start and end days in the period', () => {
+    const fy = period('2026-01-01', '2026-12-31')
+    expect(isDateInPeriod('2026-01-01', fy)).toBe(true)
+    expect(isDateInPeriod('2026-12-31', fy)).toBe(true)
+    expect(isDateInPeriod('2025-12-31', fy)).toBe(false)
+  })
+})

--- a/src/api/useFiscalPeriods.ts
+++ b/src/api/useFiscalPeriods.ts
@@ -3,6 +3,7 @@ import { computed, type Ref, type ComputedRef } from 'vue'
 import { createCrudHooks } from './factory'
 import { api } from './client'
 import type { components } from './types'
+import { parseCalendarDate, toLocalISODate } from '@/utils/format'
 
 // ============================================
 // Types
@@ -205,9 +206,9 @@ export function getFiscalPeriodStatus(period: FiscalPeriod): {
  * Check if a date falls within a fiscal period
  */
 export function isDateInPeriod(date: string, period: FiscalPeriod): boolean {
-  const d = new Date(date)
-  const start = new Date(period.start_date)
-  const end = new Date(period.end_date)
+  const d = parseCalendarDate(date)
+  const start = parseCalendarDate(period.start_date)
+  const end = parseCalendarDate(period.end_date)
   return d >= start && d <= end
 }
 
@@ -215,7 +216,7 @@ export function isDateInPeriod(date: string, period: FiscalPeriod): boolean {
  * Get current fiscal period from a list
  */
 export function getCurrentPeriod(periods: FiscalPeriod[]): FiscalPeriod | undefined {
-  const today = new Date().toISOString().split('T')[0] ?? ''
+  const today = toLocalISODate()
   return periods.find(p => isDateInPeriod(today, p) && !p.is_closed)
 }
 
@@ -223,8 +224,8 @@ export function getCurrentPeriod(periods: FiscalPeriod[]): FiscalPeriod | undefi
  * Format fiscal period date range
  */
 export function formatPeriodRange(period: FiscalPeriod): string {
-  const start = new Date(period.start_date)
-  const end = new Date(period.end_date)
+  const start = parseCalendarDate(period.start_date)
+  const end = parseCalendarDate(period.end_date)
 
   const startMonth = start.toLocaleDateString('id-ID', { month: 'short', year: 'numeric' })
   const endMonth = end.toLocaleDateString('id-ID', { month: 'short', year: 'numeric' })

--- a/src/utils/__tests__/format.test.ts
+++ b/src/utils/__tests__/format.test.ts
@@ -15,6 +15,7 @@ import {
   formatPercent,
   formatDate,
   formatDateTime,
+  parseCalendarDate,
   formatRelativeTime,
   daysRemaining,
   truncate,
@@ -199,6 +200,22 @@ describe('formatPercent', () => {
   })
 })
 
+describe('parseCalendarDate', () => {
+  it('treats YYYY-MM-DD as a local calendar date, not UTC midnight', () => {
+    const d = parseCalendarDate('2026-01-01')
+    expect(d.getFullYear()).toBe(2026)
+    expect(d.getMonth()).toBe(0)
+    expect(d.getDate()).toBe(1)
+  })
+
+  it('keeps 31 December on 31 December', () => {
+    const d = parseCalendarDate('2026-12-31')
+    expect(d.getFullYear()).toBe(2026)
+    expect(d.getMonth()).toBe(11)
+    expect(d.getDate()).toBe(31)
+  })
+})
+
 describe('formatDate', () => {
   it('returns dash for null', () => {
     expect(formatDate(null)).toBe('-')
@@ -216,6 +233,11 @@ describe('formatDate', () => {
     const result = formatDate('2024-12-27')
     expect(result).toContain('27')
     expect(result).toContain('2024')
+  })
+
+  it('does not shift fiscal year bounds to the previous local day', () => {
+    expect(formatDate('2026-01-01')).toMatch(/1\s+Jan\s+2026/)
+    expect(formatDate('2026-12-31')).toMatch(/31\s+Des\s+2026/)
   })
 
   it('formats Date object', () => {

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -92,11 +92,32 @@ export function formatPercent(value: NumericValue, decimals: number = 1): string
 }
 
 /**
+ * Parse a calendar date without UTC off-by-one.
+ *
+ * `new Date('2026-01-01')` is UTC midnight. In timezones west of UTC that
+ * becomes 31 Dec locally, so fiscal-period lists showed 31 Des–30 Des while
+ * `<input type="date">` (YYYY-MM-DD) still showed 01/01–12/31.
+ */
+export function parseCalendarDate(date: string | Date): Date {
+  if (date instanceof Date) {
+    return date
+  }
+
+  const dateOnly = /^(\d{4})-(\d{2})-(\d{2})$/.exec(date.trim())
+  if (dateOnly) {
+    return new Date(Number(dateOnly[1]), Number(dateOnly[2]) - 1, Number(dateOnly[3]))
+  }
+
+  return new Date(date)
+}
+
+/**
  * Format date in Indonesian format (27 Des 2024)
  */
 export function formatDate(date: string | Date | null | undefined): string {
   if (!date) return '-'
-  const d = new Date(date)
+  const d = parseCalendarDate(date)
+  if (Number.isNaN(d.getTime())) return '-'
   return new Intl.DateTimeFormat('id-ID', {
     day: 'numeric',
     month: 'short',
@@ -156,7 +177,7 @@ export function toLocalISODate(date: Date = new Date()): string {
  * Calculate days remaining until date
  */
 export function daysRemaining(dueDate: string | Date): { days: number; isOverdue: boolean } {
-  const due = new Date(dueDate)
+  const due = parseCalendarDate(dueDate)
   const now = new Date()
   const diffMs = due.getTime() - now.getTime()
   const diffDays = Math.ceil(diffMs / (1000 * 60 * 60 * 24))


### PR DESCRIPTION
Fixes satriyop/enter365#123

## Why this PR exists
On live aidev, **Periode Fiskal** list/banner showed Tahun Fiskal 2026 as **31 Des 2025 – 30 Des 2026**, while Edit showed **01/01/2026 – 12/31/2026**. Accountants lock/post against the displayed range, so the off-by-one is a real close-date bug, not cosmetics.

## Root cause
`formatDate('2026-01-01')` used `new Date('YYYY-MM-DD')`. ES date-only strings are **UTC midnight**. In any timezone west of UTC that is the **previous local day**. The edit form uses `start_date.split('T')[0]` in `<input type="date">`, which keeps the calendar day. List and banner also used `formatPeriodRange` with the same UTC parse.

Backend `FiscalPeriodResource` already returns `toDateString()` (`YYYY-MM-DD`). No API change.

## What changed
- `parseCalendarDate()` treats `YYYY-MM-DD` as local Y/M/D.
- `formatDate`, `daysRemaining`, `formatPeriodRange`, `isDateInPeriod` use it.
- Current-period detection uses `toLocalISODate()` instead of UTC `toISOString().split('T')[0]`.

## How to review
1. **Code:** `src/utils/format.ts` (`parseCalendarDate`) and `src/api/useFiscalPeriods.ts`.
2. **Tests:** `TZ=America/New_York npm run test:run -- src/utils/__tests__/format.test.ts src/api/__tests__/fiscalPeriodDates.test.ts` (76 passed). The US TZ is the repro: without the fix, `2026-01-01` formats as 31 Des 2025.
3. **Live after merge:** `/accounting/fiscal-periods` list + banner must match Edit start/end (1 Jan–31 Dec for calendar FY 2026).

## Out of scope
Date-times with a real clock (`formatDateTime`) still use `new Date(iso)`. Do not treat those as calendar dates.

## Issue acceptance
- [x] List, banner, and edit show the same inclusive start/end
- [x] No UTC date displayed as previous local day