### PR TITLE
fix(nav): Laporan under Accounting sidebar (#129)

### DIFF
--- a/src/config/__tests__/nav.test.ts
+++ b/src/config/__tests__/nav.test.ts
@@ -15,6 +15,14 @@ describe('navigation permission keys', () => {
     expect(item('Reports').permission).toBe('reports.financial')
   })
 
+  it('puts Laporan under Accounting, not Finance (#129)', () => {
+    const accounting = navigation.find((group) => group.label === 'Accounting')
+    const finance = navigation.find((group) => group.label === 'Finance')
+    expect(accounting?.items.map((row) => row.name)).toContain('Reports')
+    expect(accounting?.items.find((row) => row.name === 'Reports')?.path).toBe('/reports')
+    expect(finance?.items.map((row) => row.name)).not.toContain('Reports')
+  })
+
   it('gates Reminders and Overdue on the invoices pack', () => {
     expect(item('Reminders').feature).toBe('invoices')
     expect(item('Overdue Management').feature).toBe('invoices')

--- a/src/config/nav.ts
+++ b/src/config/nav.ts
@@ -82,6 +82,7 @@ export const navigation: NavGroup[] = [
       { name: 'Budgets', path: '/accounting/budgets', icon: '📊', permission: 'budgets.view', feature: 'budgeting' },
       { name: 'Bank Reconciliation', path: '/accounting/bank-reconciliation', icon: '🏦', permission: 'journals.view', feature: 'bank_reconciliation' },
       { name: 'Recurring Templates', path: '/accounting/recurring-templates', icon: '🔄', permission: 'journals.view', feature: 'recurring' },
+      { name: 'Reports', path: '/reports', icon: '📊', permission: 'reports.financial' },
     ],
   },
   {
@@ -92,7 +93,6 @@ export const navigation: NavGroup[] = [
       { name: 'Reminders', path: '/finance/reminders', icon: '🔔', permission: 'invoices.view', feature: 'invoices' },
       { name: 'Overdue Management', path: '/sales/overdue-dashboard', icon: '⚠️', permission: 'invoices.view', feature: 'invoices' },
       { name: 'Bills', path: '/bills', icon: '📑', permission: 'bills.view' },
-      { name: 'Reports', path: '/reports', icon: '📊', permission: 'reports.financial' },
     ],
   },
   {


### PR DESCRIPTION
Fixes satriyop/enter365#129

## Why this PR exists
Live aidev: \`/reports\` loads Financial/Sales/Purchase/Inventory/Tax/COGS/Project/Manufacturing reports, but **Laporan is not in the left sidebar under AKUNTANSI**. Testers had to type the URL. Odoo exposes Reporting from the Accounting app menu.

## Root cause
\`src/config/nav.ts\` placed \`Reports\` (\`/reports\`, permission \`reports.financial\`) in the **Finance** group. POS chrome already translates Reports → Laporan, so the item existed — just not where accountants look. Finance on the mockup is Payments/Bills; Accounting is CoA/Journals/Fiscal Periods.

## What changed
Moved the existing nav item from Finance to Accounting (after Recurring Templates). No new route, permission, or pack flag.

## How to review
1. **Code:** one item move in \`src/config/nav.ts\`.
2. **Test:** \`npm run test:run -- src/config/__tests__/nav.test.ts\` — asserts Accounting contains Reports at \`/reports\` and Finance does not.
3. **Live after merge:** as admin@demo.com, sidebar **AKUNTANSI** must list **Laporan** opening \`/reports\`. Command palette Reports can stay (already in searchCatalog).

## Out of scope
Does not add Reporting under Inventory/Sales apps. Issue acceptance is a sidebar entry under ACCOUNTING or top-level; Accounting is the Odoo analogue.

## Issue acceptance
- [x] Sidebar entry (Laporan) under ACCOUNTING that opens \`/reports\`