### PR TITLE
fix(purchasing): PO product + vendor pricelist after pack-on (#128)

### DIFF
--- a/src/pages/purchasing/purchase-orders/PurchaseOrderFormPage.vue
+++ b/src/pages/purchasing/purchase-orders/PurchaseOrderFormPage.vue
@@ -18,7 +18,7 @@ import {
 } from '@/utils/validation'
 import { setServerErrors } from '@/composables/useValidatedForm'
 import { formatCurrency, CURRENCY_OPTIONS } from '@/utils/format'
-import { priceForVendor } from '@/utils/vendorPrice'
+import { priceForVendor, vendorPriceSource } from '@/utils/vendorPrice'
 import { ArrowLeft, Plus, X } from 'lucide-vue-next'
 import {
   Button,
@@ -224,6 +224,18 @@ function onProductSelect(index: number, productId: number | null) {
 
 function onQuantityChange(index: number) {
   resolveLineVendorPrice(index)
+}
+
+function linePriceHint(index: number): string {
+  const item = form.items?.[index]
+  if (!item?.product_id || !products.value) return ''
+  const product = products.value.find(p => Number(p.id) === item.product_id)
+  if (!product) return ''
+  const source = vendorPriceSource(product, contactId.value ? Number(contactId.value) : null, Number(item.quantity) || 1)
+  if (source === 'pricelist') return 'Vendor pricelist'
+  if (source === 'purchase_price') return 'Product purchase price'
+  if (source === 'selling_price') return 'Product selling price'
+  return ''
 }
 
 watch(contactId, (newId, oldId) => {
@@ -448,14 +460,16 @@ const contactOptions = computed(() => {
                   <select
                     :value="field.value.product_id ?? ''"
                     :data-testid="`po-item-${index}-product`"
+                    :disabled="!contactId"
+                    :title="contactId ? undefined : 'Select a vendor first to use the vendor pricelist'"
                     @change="(e) => {
                       const val = (e.target as HTMLSelectElement).value
                       field.value.product_id = val ? Number(val) : null
                       onProductSelect(index, field.value.product_id)
                     }"
-                    class="w-full px-2 py-1.5 rounded border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100 text-sm focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+                    class="w-full px-2 py-1.5 rounded border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100 text-sm focus:ring-2 focus:ring-primary-500 focus:border-transparent disabled:opacity-60"
                   >
-                    <option value="">Custom</option>
+                    <option value="">Select product…</option>
                     <option
                       v-for="opt in products"
                       :key="opt.id"
@@ -464,6 +478,9 @@ const contactOptions = computed(() => {
                       {{ opt.sku }} - {{ opt.name }}
                     </option>
                   </select>
+                  <p v-if="!contactId && index === 0" class="mt-1 text-xs text-slate-500 dark:text-slate-400">
+                    Select a vendor first for pricelist prices. Custom description-only lines stay available.
+                  </p>
                 </td>
                 <td class="px-3 py-2">
                   <input
@@ -501,6 +518,13 @@ const contactOptions = computed(() => {
                     :min="0"
                     :data-testid="`po-item-${index}-price`"
                   />
+                  <p
+                    v-if="linePriceHint(index)"
+                    class="mt-1 text-xs text-slate-500 dark:text-slate-400"
+                    :data-testid="`po-item-${index}-price-source`"
+                  >
+                    {{ linePriceHint(index) }}
+                  </p>
                 </td>
                 <td class="px-3 py-2">
                   <input

--- a/src/pages/purchasing/purchase-orders/__tests__/poVendorPricelist.test.ts
+++ b/src/pages/purchasing/purchase-orders/__tests__/poVendorPricelist.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+describe('PO vendor pricelist (#128)', () => {
+  it('offers catalog products after vendor is selected, not Custom as the only path', () => {
+    const form = readFileSync(resolve(__dirname, '../PurchaseOrderFormPage.vue'), 'utf8')
+
+    expect(form).toContain('priceForVendor')
+    expect(form).toContain('vendorPriceSource')
+    expect(form).toContain('Select product…')
+    expect(form).toContain(':disabled="!contactId"')
+    expect(form).toContain('Vendor pricelist')
+    expect(form).toContain('po-item-${index}-price-source')
+    expect(form).not.toMatch(/<option value="">Custom<\/option>/)
+  })
+})

--- a/src/utils/__tests__/vendorPrice.test.ts
+++ b/src/utils/__tests__/vendorPrice.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { priceForVendor } from '../vendorPrice'
+import { priceForVendor, vendorPriceSource } from '../vendorPrice'
 
 const product = {
   purchase_price: 80_000,
@@ -20,5 +20,11 @@ describe('priceForVendor', () => {
   it('falls back to purchase_price when vendor or qty does not match', () => {
     expect(priceForVendor(product, 9, 10)).toBe(80_000)
     expect(priceForVendor(product, null, 10)).toBe(80_000)
+  })
+
+  it('labels pricelist vs purchase-price fallback (#128)', () => {
+    expect(vendorPriceSource(product, 7, 1)).toBe('pricelist')
+    expect(vendorPriceSource(product, 9, 10)).toBe('purchase_price')
+    expect(vendorPriceSource(product, null, 10)).toBe('purchase_price')
   })
 })

--- a/src/utils/vendorPrice.ts
+++ b/src/utils/vendorPrice.ts
@@ -4,6 +4,45 @@ export type VendorPricelistLine = {
   price: number
 }
 
+export type VendorPriceSource = 'pricelist' | 'purchase_price' | 'selling_price' | 'none'
+
+function matchedVendorLine(
+  product: {
+    vendor_pricelists?: VendorPricelistLine[] | null
+  },
+  vendorId: number | null | undefined,
+  qty: number,
+): VendorPricelistLine | undefined {
+  if (!vendorId) {
+    return undefined
+  }
+
+  return (product.vendor_pricelists ?? [])
+    .filter((line) => Number(line.contact_id) === Number(vendorId) && Number(line.min_qty) <= qty)
+    .sort((a, b) => Number(b.min_qty) - Number(a.min_qty))[0]
+}
+
+export function vendorPriceSource(
+  product: {
+    purchase_price?: number | null
+    selling_price?: number | null
+    vendor_pricelists?: VendorPricelistLine[] | null
+  },
+  vendorId: number | null | undefined,
+  qty: number,
+): VendorPriceSource {
+  if (matchedVendorLine(product, vendorId, qty)) {
+    return 'pricelist'
+  }
+  if (Number(product.purchase_price)) {
+    return 'purchase_price'
+  }
+  if (Number(product.selling_price)) {
+    return 'selling_price'
+  }
+  return 'none'
+}
+
 export function priceForVendor(
   product: {
     purchase_price?: number | null
@@ -13,14 +52,10 @@ export function priceForVendor(
   vendorId: number | null | undefined,
   qty: number,
 ): number {
-  const fallback = Number(product.purchase_price) || Number(product.selling_price) || 0
-  if (!vendorId) {
-    return fallback
+  const match = matchedVendorLine(product, vendorId, qty)
+  if (match) {
+    return Number(match.price)
   }
 
-  const match = (product.vendor_pricelists ?? [])
-    .filter((line) => Number(line.contact_id) === Number(vendorId) && Number(line.min_qty) <= qty)
-    .sort((a, b) => Number(b.min_qty) - Number(a.min_qty))[0]
-
-  return match ? Number(match.price) : fallback
+  return Number(product.purchase_price) || Number(product.selling_price) || 0
 }


### PR DESCRIPTION
Fixes satriyop/enter365#128

## Why this PR exists
After PO pack-on, New RFQ (\`/purchasing/purchase-orders/new\`) still showed line **Product = Custom** and a free **Price**. Odoo prices RFQ lines from the product’s vendor pricelist once a vendor is chosen. #102 closed when the pack was off; this is the pack-on follow-up.

## Root cause
\`priceForVendor()\` and \`onProductSelect\` already existed (FE #68). The live form still:
1. Defaulted the native \`<select>\` to \`<option value=\"\">Custom</option>\`, so catalog looked like a hidden extra.
2. Let you pick a product before a vendor, so the price box was a typed number, not a pricelist fill.
3. Did not say whether the filled price was pricelist vs purchase price.

Backend already returns \`vendor_pricelists\` on product index/lookup.

## What changed
- Product dropdown is **Select product…** (empty still means custom/free-text).
- Dropdown is disabled until Vendor is set.
- Selecting a product still fills description/unit/tax and **unit_price via \`priceForVendor\`**.
- Changing vendor or qty re-resolves the matching min_qty line.
- Hint under Price: \`Vendor pricelist\` / \`Product purchase price\`.

## How to review
1. **Logic:** \`src/utils/vendorPrice.ts\` (\`vendorPriceSource\` + shared match).
2. **UI:** \`PurchaseOrderFormPage.vue\` product select + price-source hint.
3. **Tests:** \`npm run test:run -- src/utils/__tests__/vendorPrice.test.ts src/pages/purchasing/purchase-orders/__tests__/poVendorPricelist.test.ts\`
4. **Live after merge:** pick vendor first → product SKU → Price should fill from that vendor’s pricelist (or purchase price if none). Custom remains by leaving Select product….

## Out of scope
Does not add a separate “pricelist picker” widget. Odoo uses the product’s vendor lines; so do we.

## Issue acceptance
- [x] After vendor is selected, product lines offer catalog products and fill unit price from that vendor’s pricelist (fallback purchase price)
- [x] Custom line remains available, but is not the only path