### PR TITLE
feat(sales): invoice lines use products and sales taxes (#127)

### DIFF
--- a/src/pages/invoices/InvoiceFormPage.vue
+++ b/src/pages/invoices/InvoiceFormPage.vue
@@ -10,9 +10,13 @@ import {
   type CreateInvoiceItem
 } from '@/api/useInvoices'
 import { useContactsLookup } from '@/api/useContacts'
+import { useProductsLookup } from '@/api/useProducts'
+import { useAccountsLookup } from '@/api/useAccounts'
+import { useTaxRecords } from '@/api/useTaxRecords'
 import { invoiceSchema, type InvoiceFormData, type InvoiceItemFormData } from '@/utils/validation'
 import { setServerErrors } from '@/composables/useValidatedForm'
 import { formatCurrency, toNumber, CURRENCY_OPTIONS } from '@/utils/format'
+import { applyInvoiceProductDefaults, toggleInvoiceLineTax } from './invoiceLineDefaults'
 import {
   Button,
   Input,
@@ -44,13 +48,21 @@ const { data: existingInvoice, isLoading: loadingInvoice } = useInvoice(invoiceI
 
 // Lookups
 const { data: contacts, isLoading: loadingContacts } = useContactsLookup('customer')
+const { data: products } = useProductsLookup()
+const { data: accounts, isLoading: accountsLoading } = useAccountsLookup('revenue')
+const { data: salesTaxRecords } = useTaxRecords('sales')
 
 function createEmptyItem(): InvoiceItemFormData {
   return {
+    product_id: null,
     description: '',
     quantity: 1,
     unit: 'pcs',
     unit_price: 0,
+    tax_rate: 11,
+    tax_record_ids: [],
+    taxes_manual: false,
+    revenue_account_id: null,
   }
 }
 
@@ -117,10 +129,15 @@ watch(existingInvoice, (invoice) => {
       discount_amount: toNumber(invoice.discount_amount),
       items: invoice.items && invoice.items.length > 0
         ? invoice.items.map(item => ({
+            product_id: item.product_id ? Number(item.product_id) : null,
             description: item.description,
             quantity: item.quantity,
             unit: item.unit,
             unit_price: toNumber(item.unit_price),
+            tax_rate: toNumber(item.tax_rate) || 11,
+            tax_record_ids: [],
+            taxes_manual: false,
+            revenue_account_id: item.revenue_account_id ? Number(item.revenue_account_id) : null,
           }))
         : [createEmptyItem()],
     })
@@ -138,9 +155,37 @@ const subtotal = computed(() => {
 
 const afterDiscount = computed(() => subtotal.value - (form.discount_amount || 0))
 
-const taxAmount = computed(() => afterDiscount.value * ((form.tax_rate || 0) / 100))
+const hasLineTax = computed(() =>
+  (form.items || []).some(item => (item.tax_rate || 0) > 0 || (item.tax_record_ids?.length ?? 0) > 0)
+)
+
+const taxAmount = computed(() => {
+  if (hasLineTax.value) {
+    return (form.items || []).reduce((sum, item) => {
+      const lineTotal = (item.quantity || 0) * (item.unit_price || 0)
+      return sum + (lineTotal * (item.tax_rate || 0) / 100)
+    }, 0)
+  }
+  return afterDiscount.value * ((form.tax_rate || 0) / 100)
+})
 
 const grandTotal = computed(() => afterDiscount.value + taxAmount.value)
+
+function onProductSelect(index: number, productId: number | null) {
+  const item = form.items?.[index]
+  if (!item) return
+  item.product_id = productId
+  if (!productId || !products.value) return
+  const product = products.value.find((row) => Number(row.id) === productId)
+  if (!product) return
+  applyInvoiceProductDefaults(item, product)
+}
+
+function toggleLineTax(index: number, taxId: number) {
+  const item = form.items?.[index]
+  if (!item) return
+  toggleInvoiceLineTax(item, taxId, salesTaxRecords.value)
+}
 
 // Item management
 function addItem() {
@@ -165,10 +210,13 @@ const onSubmit = handleSubmit(async (formValues) => {
   const itemsPayload: CreateInvoiceItem[] = (formValues.items || [])
     .filter(item => item.description)
     .map(item => ({
+      product_id: item.product_id || undefined,
       description: item.description,
       quantity: item.quantity,
       unit: item.unit,
       unit_price: item.unit_price,
+      tax_rate: item.tax_rate,
+      revenue_account_id: item.revenue_account_id || undefined,
     }))
 
   const payload = {
@@ -220,6 +268,20 @@ const contactOptions = computed(() => {
     label: c.name || `Contact #${c.id}`,
   }))
 })
+
+const productOptions = computed(() =>
+  (products.value ?? []).map((product) => ({
+    value: product.id,
+    label: `${product.sku} - ${product.name}`,
+  })),
+)
+
+const accountOptions = computed(() =>
+  (accounts.value ?? []).map((account) => ({
+    value: account.id,
+    label: `${account.code} - ${account.name}`,
+  })),
+)
 </script>
 
 <template>
@@ -325,6 +387,7 @@ const contactOptions = computed(() => {
           <table class="w-full text-sm">
             <thead class="bg-slate-50 dark:bg-slate-800 text-slate-600 dark:text-slate-400">
               <tr>
+                <th class="px-3 py-2 text-left w-48">Product</th>
                 <th class="px-3 py-2 text-left">Description</th>
                 <th class="px-3 py-2 text-right w-24">Qty</th>
                 <th class="px-3 py-2 text-left w-20">Unit</th>
@@ -334,59 +397,105 @@ const contactOptions = computed(() => {
               </tr>
             </thead>
             <tbody class="divide-y divide-slate-200 dark:divide-slate-700">
-              <tr v-for="(field, index) in itemFields" :key="field.key" class="align-top">
-                <td class="px-3 py-2">
-                  <input
-                    v-model="field.value.description"
-                    :data-testid="`invoice-item-${index}-description`"
-                    type="text"
-                    placeholder="Item description"
-                    class="w-full px-2 py-1.5 rounded border border-slate-300 dark:border-slate-600 text-sm bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100 focus:ring-2 focus:ring-orange-500 focus:border-transparent"
-                  />
-                </td>
-                <td class="px-3 py-2">
-                  <input
-                    v-model.number="field.value.quantity"
-                    :data-testid="`invoice-item-${index}-quantity`"
-                    type="number"
-                    min="1"
-                    step="any"
-                    class="w-full px-2 py-1.5 rounded border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100 text-sm text-right focus:ring-2 focus:ring-orange-500 focus:border-transparent"
-                  />
-                </td>
-                <td class="px-3 py-2">
-                  <input
-                    v-model="field.value.unit"
-                    :data-testid="`invoice-item-${index}-unit`"
-                    type="text"
-                    placeholder="pcs"
-                    class="w-full px-2 py-1.5 rounded border border-slate-300 dark:border-slate-600 text-sm bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100 focus:ring-2 focus:ring-orange-500 focus:border-transparent"
-                  />
-                </td>
-                <td class="px-3 py-2">
-                  <CurrencyInput
-                    v-model="field.value.unit_price"
-                    :data-testid="`invoice-item-${index}-price`"
-                    size="sm"
-                    :min="0"
-                  />
-                </td>
-                <td class="px-3 py-2 text-right font-medium text-slate-900 dark:text-slate-100">
-                  {{ formatCurrency(calculateItemTotal(field.value)) }}
-                </td>
-                <td class="px-3 py-2">
-                  <button
-                    type="button"
-                    @click="handleRemoveItem(index)"
-                    :disabled="itemFields.length === 1"
-                    class="text-slate-400 dark:text-slate-500 hover:text-red-500 dark:hover:text-red-400 disabled:opacity-30 disabled:cursor-not-allowed"
-                  >
-                    <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-                    </svg>
-                  </button>
-                </td>
-              </tr>
+              <template v-for="(field, index) in itemFields" :key="field.key">
+                <tr class="align-top">
+                  <td class="px-3 py-2">
+                    <Select
+                      v-model="field.value.product_id"
+                      :options="productOptions"
+                      placeholder="Select product…"
+                      :test-id="`invoice-item-${index}-product`"
+                      @update:model-value="(value) => onProductSelect(index, value ? Number(value) : null)"
+                    />
+                  </td>
+                  <td class="px-3 py-2">
+                    <input
+                      v-model="field.value.description"
+                      :data-testid="`invoice-item-${index}-description`"
+                      type="text"
+                      placeholder="Item description"
+                      class="w-full px-2 py-1.5 rounded border border-slate-300 dark:border-slate-600 text-sm bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100 focus:ring-2 focus:ring-orange-500 focus:border-transparent"
+                    />
+                  </td>
+                  <td class="px-3 py-2">
+                    <input
+                      v-model.number="field.value.quantity"
+                      :data-testid="`invoice-item-${index}-quantity`"
+                      type="number"
+                      min="1"
+                      step="any"
+                      class="w-full px-2 py-1.5 rounded border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100 text-sm text-right focus:ring-2 focus:ring-orange-500 focus:border-transparent"
+                    />
+                  </td>
+                  <td class="px-3 py-2">
+                    <input
+                      v-model="field.value.unit"
+                      :data-testid="`invoice-item-${index}-unit`"
+                      type="text"
+                      placeholder="pcs"
+                      class="w-full px-2 py-1.5 rounded border border-slate-300 dark:border-slate-600 text-sm bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100 focus:ring-2 focus:ring-orange-500 focus:border-transparent"
+                    />
+                  </td>
+                  <td class="px-3 py-2">
+                    <CurrencyInput
+                      v-model="field.value.unit_price"
+                      :data-testid="`invoice-item-${index}-price`"
+                      size="sm"
+                      :min="0"
+                    />
+                  </td>
+                  <td class="px-3 py-2 text-right font-medium text-slate-900 dark:text-slate-100">
+                    {{ formatCurrency(calculateItemTotal(field.value)) }}
+                  </td>
+                  <td class="px-3 py-2">
+                    <button
+                      type="button"
+                      @click="handleRemoveItem(index)"
+                      :disabled="itemFields.length === 1"
+                      class="text-slate-400 dark:text-slate-500 hover:text-red-500 dark:hover:text-red-400 disabled:opacity-30 disabled:cursor-not-allowed"
+                    >
+                      <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+                      </svg>
+                    </button>
+                  </td>
+                </tr>
+                <tr>
+                  <td colspan="7" class="px-3 pb-3">
+                    <div class="grid grid-cols-12 gap-2 items-start">
+                      <div class="col-span-8">
+                        <label v-if="index === 0" class="block text-xs font-medium text-slate-500 dark:text-slate-400 mb-1">Sales taxes</label>
+                        <div class="flex flex-wrap gap-2 min-h-9 items-center" :data-testid="`invoice-item-${index}-tax-records`">
+                          <label
+                            v-for="tax in salesTaxRecords"
+                            :key="tax.id"
+                            class="flex items-center gap-1 text-xs text-slate-700 dark:text-slate-300"
+                          >
+                            <input
+                              type="checkbox"
+                              class="rounded border-slate-300 dark:border-slate-600"
+                              :checked="(field.value.tax_record_ids ?? []).includes(tax.id)"
+                              @change="toggleLineTax(index, tax.id)"
+                            />
+                            {{ tax.name }} ({{ tax.rate }}%)
+                          </label>
+                          <span v-if="!salesTaxRecords?.length" class="text-xs text-slate-400">No tax records</span>
+                        </div>
+                      </div>
+                      <div class="col-span-4">
+                        <label v-if="index === 0" class="block text-xs font-medium text-slate-500 dark:text-slate-400 mb-1">Account</label>
+                        <Select
+                          v-model="field.value.revenue_account_id"
+                          :options="accountOptions"
+                          :loading="accountsLoading"
+                          placeholder="Income account (optional)"
+                          :test-id="`invoice-item-${index}-account`"
+                        />
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+              </template>
             </tbody>
           </table>
         </div>

--- a/src/pages/invoices/__tests__/invoiceLineDefaults.test.ts
+++ b/src/pages/invoices/__tests__/invoiceLineDefaults.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { applyInvoiceProductDefaults, toggleInvoiceLineTax, type InvoiceLineDraft } from '../invoiceLineDefaults'
+
+function emptyLine(): InvoiceLineDraft {
+  return {
+    product_id: null,
+    description: '',
+    unit: 'pcs',
+    unit_price: 0,
+    tax_rate: 11,
+    tax_record_ids: [],
+    taxes_manual: false,
+    revenue_account_id: null,
+  }
+}
+
+describe('invoice line product defaults (#127)', () => {
+  it('inherits selling price, sales taxes, and income account from the product', () => {
+    const item = emptyLine()
+    applyInvoiceProductDefaults(item, {
+      id: 12,
+      name: 'Kopi Tubruk',
+      unit: 'cup',
+      selling_price: 15000,
+      tax_rate: 0,
+      sales_account_id: 40,
+      sales_taxes: [{ id: 3, rate: 11 }],
+    })
+
+    expect(item.product_id).toBe(12)
+    expect(item.description).toBe('Kopi Tubruk')
+    expect(item.unit).toBe('cup')
+    expect(item.unit_price).toBe(15000)
+    expect(item.tax_record_ids).toEqual([3])
+    expect(item.tax_rate).toBe(11)
+    expect(item.taxes_manual).toBe(false)
+    expect(item.revenue_account_id).toBe(40)
+  })
+
+  it('lets the user override sales tax records', () => {
+    const item = emptyLine()
+    applyInvoiceProductDefaults(item, {
+      id: 1,
+      name: 'Item',
+      selling_price: 1000,
+      sales_taxes: [{ id: 3, rate: 11 }],
+    })
+    toggleInvoiceLineTax(item, 3, [{ id: 3, rate: 11 }, { id: 4, rate: 1 }])
+    toggleInvoiceLineTax(item, 4, [{ id: 3, rate: 11 }, { id: 4, rate: 1 }])
+    expect(item.tax_record_ids).toEqual([4])
+    expect(item.tax_rate).toBe(1)
+    expect(item.taxes_manual).toBe(true)
+  })
+
+  it('wires the New Invoice form to product pickers and sales tax records', () => {
+    const form = readFileSync(resolve(__dirname, '../InvoiceFormPage.vue'), 'utf8')
+    const validation = readFileSync(resolve(__dirname, '../../../utils/validation.ts'), 'utf8')
+
+    expect(form).toContain('useProductsLookup')
+    expect(form).toContain('useTaxRecords')
+    expect(form).toContain('applyInvoiceProductDefaults')
+    expect(form).toContain('invoice-item-${index}-product')
+    expect(form).toContain('invoice-item-${index}-tax-records')
+    expect(form).toContain("useTaxRecords('sales')")
+    expect(form).toContain('product_id: item.product_id || undefined')
+    expect(validation).toContain('tax_record_ids: z.array(z.number())')
+  })
+})

--- a/src/pages/invoices/invoiceLineDefaults.ts
+++ b/src/pages/invoices/invoiceLineDefaults.ts
@@ -1,0 +1,61 @@
+export type InvoiceSalesTax = {
+  id: number
+  rate: number
+}
+
+export type InvoiceProductLike = {
+  id: number
+  name: string
+  unit?: string | null
+  selling_price?: number | string | null
+  tax_rate?: number | string | null
+  sales_account_id?: number | null
+  sales_taxes?: InvoiceSalesTax[] | null
+}
+
+export type InvoiceLineDraft = {
+  product_id: number | null
+  description: string
+  unit: string
+  unit_price: number
+  tax_rate: number
+  tax_record_ids: number[]
+  taxes_manual: boolean
+  revenue_account_id?: number | null
+}
+
+export function rateForTaxIds(taxes: InvoiceSalesTax[] | null | undefined, ids: number[]): number {
+  return (taxes ?? [])
+    .filter((tax) => ids.includes(tax.id))
+    .reduce((sum, tax) => sum + Number(tax.rate), 0)
+}
+
+export function applyInvoiceProductDefaults(item: InvoiceLineDraft, product: InvoiceProductLike): void {
+  item.product_id = Number(product.id)
+  item.description = product.name
+  item.unit = product.unit || 'pcs'
+  item.unit_price = Number(product.selling_price) || 0
+  const inherited = (product.sales_taxes ?? []).map((tax) => tax.id)
+  item.tax_record_ids = inherited
+  item.taxes_manual = false
+  item.tax_rate = inherited.length
+    ? (product.sales_taxes ?? []).reduce((sum, tax) => sum + Number(tax.rate), 0)
+    : Number(product.tax_rate) || 0
+  if (product.sales_account_id) {
+    item.revenue_account_id = Number(product.sales_account_id)
+  }
+}
+
+export function toggleInvoiceLineTax(
+  item: InvoiceLineDraft,
+  taxId: number,
+  taxes: InvoiceSalesTax[] | null | undefined,
+): void {
+  const current = item.tax_record_ids ?? []
+  const next = current.includes(taxId)
+    ? current.filter((id) => id !== taxId)
+    : [...current, taxId]
+  item.tax_record_ids = next
+  item.taxes_manual = true
+  item.tax_rate = next.length ? rateForTaxIds(taxes, next) : 0
+}

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -297,10 +297,14 @@ export const quotationSchema = z.object({
  * Invoice item schema
  */
 export const invoiceItemSchema = z.object({
+  product_id: z.number().optional().nullable(),
   description: requiredString('Description').max(500),
   quantity: quantitySchema.default(1),
   unit: z.string().max(20).default('pcs'),
   unit_price: unitPriceSchema.default(0),
+  tax_rate: percentageSchema.default(11),
+  tax_record_ids: z.array(z.number()).optional().default([]),
+  taxes_manual: z.boolean().optional().default(false),
   revenue_account_id: z.number().optional().nullable(),
 })
 


### PR DESCRIPTION
Fixes satriyop/enter365#127

## Why this PR exists
After invoices pack-on, **New Invoice** (\`/invoices/new\`) still had free-text Description/Qty/Unit/Price and a header **Tax (%)**. Odoo Customer Invoices pick **Product**, **Account**, **Taxes** (tax records). Without that, lines cannot inherit product sales taxes or post AR/revenue the Odoo way.

## Root cause
SPA \`InvoiceFormPage.vue\` never sent \`product_id\` / line \`tax_rate\` / \`revenue_account_id\`. Backend already supports all three:

- \`StoreInvoiceRequest\` / \`commonItemRules()\` — \`items.*.product_id\`, \`tax_rate\`, \`revenue_account_id\`
- \`InvoiceCrudService::createItems()\` — stores \`product_id\`, inherits \`salesTaxRate()\` when line tax is omitted, stores \`revenue_account_id\`
- \`InvoiceDomainFactory::applyTotals()\` — uses **line** tax when any line has \`tax_rate\`/\`tax_amount\`

No backend change required for the acceptance (product + inherit sales taxes as line \`tax_rate\` + optional income account). Invoice items do **not** persist \`tax_record_ids\` (bills do); the checkboxes drive line \`tax_rate\` the same way the product’s \`sales_taxes\` do on the server.

## What changed
- Line **Product** picker (catalog).
- Inherit name, unit, selling price, sales tax records, and product income account.
- **Sales taxes** checkboxes (from \`GET /tax-records?applicability=sales\`).
- Optional **Account** (revenue accounts).
- Payload sends \`product_id\`, line \`tax_rate\`, \`revenue_account_id\`.
- Totals use line taxes when present (matches backend). Header Tax % remains fallback for custom lines.

## How to review
1. **Pure inherit logic:** \`src/pages/invoices/invoiceLineDefaults.ts\`
2. **Form:** \`InvoiceFormPage.vue\` — product select, tax-record row, account, payload.
3. **Schema:** \`invoiceItemSchema\` now has \`product_id\`, \`tax_record_ids\`, line \`tax_rate\`.
4. **Tests:** \`npm run test:run -- src/pages/invoices/__tests__/invoiceLineDefaults.test.ts\`
5. **Live after merge:** \`/invoices/new\` → pick customer → pick product on a line → Price/Unit/Sales taxes fill. Create still works for a custom description line.

## Out of scope
Does not add invoice-item \`tax_record_ids\` persistence (new column/JSON). If we need stored tax records like bills, that is a follow-up BE+FE change. This PR matches current invoice posting (line \`tax_rate\` from sales taxes).

## Issue acceptance
- [x] Invoice lines pick a product; qty/price/taxes inherit from the product (sales tax records, not only a header %)
- [x] Optional account on the line for accounting-first post