### PR TITLE
feat(sales): delivery order lines pick products (#130)

### DIFF
--- a/src/pages/sales/delivery-orders/DeliveryOrderFormPage.vue
+++ b/src/pages/sales/delivery-orders/DeliveryOrderFormPage.vue
@@ -11,7 +11,9 @@ import {
 } from '@/api/useDeliveryOrders'
 import { useContactsLookup } from '@/api/useContacts'
 import { useWarehousesLookup } from '@/api/useInventory'
+import { useProductsLookup } from '@/api/useProducts'
 import { deliveryOrderSchema, type DeliveryOrderFormData, type DeliveryOrderItemFormData } from '@/utils/validation'
+import { applyDeliveryProductDefaults } from './deliveryOrderLineDefaults'
 import { setServerErrors } from '@/composables/useValidatedForm'
 import {
   Button,
@@ -44,9 +46,11 @@ const { data: existingDO, isLoading: loadingDO } = useDeliveryOrder(doIdRef)
 // Lookups
 const { data: contacts, isLoading: loadingContacts } = useContactsLookup('customer')
 const { data: warehouses, isLoading: loadingWarehouses } = useWarehousesLookup()
+const { data: products } = useProductsLookup()
 
 function createEmptyItem(): DeliveryOrderItemFormData {
   return {
+    product_id: null,
     description: '',
     quantity: 1,
     unit: 'pcs',
@@ -98,7 +102,7 @@ watch(existingDO, (dorder) => {
       notes: dorder.notes ?? '',
       items: dorder.items && dorder.items.length > 0
         ? dorder.items.map(item => ({
-            product_id: item.product_id || undefined,
+            product_id: item.product_id ? Number(item.product_id) : null,
             description: item.description || '',
             quantity: item.quantity,
             unit: item.unit || 'pcs',
@@ -120,6 +124,16 @@ function handleRemoveItem(index: number) {
   }
 }
 
+function onProductSelect(index: number, productId: number | null) {
+  const item = itemFields.value[index]?.value
+  if (!item) return
+  item.product_id = productId
+  if (!productId || !products.value) return
+  const product = products.value.find((row) => Number(row.id) === productId)
+  if (!product) return
+  applyDeliveryProductDefaults(item, product)
+}
+
 // Form submission
 const createMutation = useCreateDeliveryOrder()
 const updateMutation = useUpdateDeliveryOrder()
@@ -130,7 +144,7 @@ const isSubmitting = computed(() =>
 
 const onSubmit = handleSubmit(async (formValues) => {
   const itemsPayload: CreateDeliveryOrderItem[] = (formValues.items || [])
-    .filter(item => item.description)
+    .filter(item => item.description || item.product_id)
     .map(item => ({
       product_id: item.product_id || undefined,
       description: item.description,
@@ -186,6 +200,13 @@ const warehouseOptions = computed(() => {
     })),
   ]
 })
+
+const productOptions = computed(() =>
+  (products.value ?? []).map((product) => ({
+    value: product.id,
+    label: `${product.sku} - ${product.name}`,
+  })),
+)
 </script>
 
 <template>
@@ -288,6 +309,7 @@ const warehouseOptions = computed(() => {
           <table class="w-full text-sm">
             <thead class="bg-slate-50 dark:bg-slate-800 text-slate-600 dark:text-slate-400">
               <tr>
+                <th class="px-3 py-2 text-left w-56">Product</th>
                 <th class="px-3 py-2 text-left">Description</th>
                 <th class="px-3 py-2 text-right w-24">Qty</th>
                 <th class="px-3 py-2 text-left w-20">Unit</th>
@@ -296,6 +318,15 @@ const warehouseOptions = computed(() => {
             </thead>
             <tbody class="divide-y divide-slate-200 dark:divide-slate-700">
               <tr v-for="(field, index) in itemFields" :key="field.key" class="align-top">
+                <td class="px-3 py-2">
+                  <Select
+                    v-model="field.value.product_id"
+                    :options="productOptions"
+                    placeholder="Select product…"
+                    :test-id="`do-item-${index}-product`"
+                    @update:model-value="(value) => onProductSelect(index, value ? Number(value) : null)"
+                  />
+                </td>
                 <td class="px-3 py-2">
                   <input
                     v-model="field.value.description"

--- a/src/pages/sales/delivery-orders/__tests__/deliveryOrderProduct.test.ts
+++ b/src/pages/sales/delivery-orders/__tests__/deliveryOrderProduct.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { applyDeliveryProductDefaults } from '../deliveryOrderLineDefaults'
+
+describe('delivery order product lines (#130)', () => {
+  it('inherits description and unit from the picked product', () => {
+    const item = { product_id: null as number | null, description: '', unit: 'pcs' }
+    applyDeliveryProductDefaults(item, { id: 9, name: 'MCB 16A', unit: 'pcs' })
+    expect(item.product_id).toBe(9)
+    expect(item.description).toBe('MCB 16A')
+    expect(item.unit).toBe('pcs')
+  })
+
+  it('shows a product picker on the New DO form', () => {
+    const form = readFileSync(resolve(__dirname, '../DeliveryOrderFormPage.vue'), 'utf8')
+    expect(form).toContain('useProductsLookup')
+    expect(form).toContain('applyDeliveryProductDefaults')
+    expect(form).toContain('do-item-${index}-product')
+    expect(form).toContain('product_id: item.product_id || undefined')
+  })
+})

--- a/src/pages/sales/delivery-orders/deliveryOrderLineDefaults.ts
+++ b/src/pages/sales/delivery-orders/deliveryOrderLineDefaults.ts
@@ -1,0 +1,17 @@
+export type DeliveryProductLike = {
+  id: number
+  name: string
+  unit?: string | null
+}
+
+export type DeliveryLineDraft = {
+  product_id?: number | null
+  description: string
+  unit: string
+}
+
+export function applyDeliveryProductDefaults(item: DeliveryLineDraft, product: DeliveryProductLike): void {
+  item.product_id = Number(product.id)
+  item.description = product.name
+  item.unit = product.unit || 'pcs'
+}


### PR DESCRIPTION
Fixes satriyop/enter365#130

## Why this PR exists
Live New Delivery Order (\`/sales/delivery-orders/new\`) items were **Description / Qty / Unit** only. Odoo stock pickings move **products**. A description-only DO cannot decrement tracked stock or inherit UoM.

## Root cause
SPA \`createEmptyItem()\` omitted \`product_id\` and the table had no product column. Payload already mapped \`product_id\` when present. Backend \`StoreDeliveryOrderRequest\` already has \`items.*.product_id\` nullable exists:products.

Stock validation against warehouse qty is server-side on ship/complete, not the create form.

## What changed
- Product picker on each DO line (catalog lookup).
- Selecting a product fills description + unit.
- Empty product still allows a custom description line (API permits nullable product_id).
- Edit maps existing \`product_id\` back into the select.

## How to review
1. **Helper:** \`deliveryOrderLineDefaults.ts\`
2. **Form:** \`DeliveryOrderFormPage.vue\` product column + \`onProductSelect\`
3. **Tests:** \`npm run test:run -- src/pages/sales/delivery-orders/__tests__/deliveryOrderProduct.test.ts\`
4. **Live after merge:** New DO → pick customer/warehouse → pick product on a line → Description/Unit fill → create. Confirm DO still posts \`product_id\`.

## Out of scope
Does not add invoice/SO line picker or client-side stock qty guard. Optional in the issue; ship/complete remains the stock check.

## Issue acceptance
- [x] DO lines pick a product (qty still validated against stock on the backend ship path)