### PR TITLE
feat(mfg): material requisition lines pick products (#131)

### DIFF
--- a/src/pages/manufacturing/material-requisitions/MaterialRequisitionFormPage.vue
+++ b/src/pages/manufacturing/material-requisitions/MaterialRequisitionFormPage.vue
@@ -10,7 +10,9 @@ import {
 } from '@/api/useMaterialRequisitions'
 import { useWorkOrdersLookup } from '@/api/useWorkOrders'
 import { useWarehousesLookup } from '@/api/useInventory'
+import { useProductsLookup } from '@/api/useProducts'
 import { materialRequisitionSchema, type MaterialRequisitionFormData, type MaterialRequisitionItemFormData } from '@/utils/validation'
+import { applyMaterialRequisitionProductDefaults } from './materialRequisitionLineDefaults'
 import { setServerErrors } from '@/composables/useValidatedForm'
 import { Button, Input, FormField, Textarea, Select, Card, useToast } from '@/components/ui'
 
@@ -46,10 +48,18 @@ const warehouseOptions = computed(() =>
   }))
 )
 
+const { data: products } = useProductsLookup()
+const productOptions = computed(() =>
+  (products.value ?? []).map(product => ({
+    value: product.id,
+    label: `${product.sku} - ${product.name}`,
+  }))
+)
+
 function createEmptyItem(): MaterialRequisitionItemFormData {
   return {
     work_order_item_id: null,
-    product_id: null,
+    product_id: undefined as unknown as number,
     description: '',
     quantity_requested: 1,
     unit: 'unit',
@@ -98,7 +108,7 @@ watch(existingRequisition, (requisition) => {
       items: requisition.items && requisition.items.length > 0
         ? requisition.items.map(item => ({
             work_order_item_id: item.work_order_item_id ? Number(item.work_order_item_id) : null,
-            product_id: item.product_id ? Number(item.product_id) : null,
+            product_id: item.product_id ? Number(item.product_id) : (undefined as unknown as number),
             description: item.product?.name || '',
             quantity_requested: Number(item.quantity_requested),
             unit: item.unit || 'unit',
@@ -120,6 +130,16 @@ function handleRemoveItem(index: number) {
   }
 }
 
+function onProductSelect(index: number, productId: number | null) {
+  const item = form.items?.[index]
+  if (!item) return
+  item.product_id = productId
+  if (!productId || !products.value) return
+  const product = products.value.find((row) => Number(row.id) === productId)
+  if (!product) return
+  applyMaterialRequisitionProductDefaults(item, product)
+}
+
 // Total calculation
 const totalQuantity = computed(() =>
   (form.items || []).reduce((sum, item) => sum + (item.quantity_requested || 0), 0)
@@ -132,11 +152,12 @@ const isSubmitting = computed(() => createMutation.isPending.value || updateMuta
 
 const onSubmit = handleSubmit(async (formValues) => {
   const itemsPayload = (formValues.items || [])
-    .filter(item => item.description || item.product_id || item.work_order_item_id)
+    .filter(item => item.product_id)
     .map(item => ({
       work_order_item_id: item.work_order_item_id || undefined,
       product_id: item.product_id || undefined,
       quantity_requested: item.quantity_requested,
+      unit: item.unit || undefined,
       notes: item.notes || undefined,
     }))
 
@@ -227,8 +248,14 @@ const onSubmit = handleSubmit(async (formValues) => {
         <div class="space-y-4">
           <div v-for="(field, index) in itemFields" :key="field.key" class="grid grid-cols-12 gap-2 items-end">
             <div class="col-span-5">
-              <label v-if="index === 0" class="block text-xs font-medium text-slate-500 dark:text-slate-400 mb-1">Description</label>
-              <Input v-model="field.value.description" placeholder="Material description" />
+              <label v-if="index === 0" class="block text-xs font-medium text-slate-500 dark:text-slate-400 mb-1">Product</label>
+              <Select
+                v-model="field.value.product_id"
+                :options="productOptions"
+                placeholder="Select product"
+                :test-id="`mr-item-${index}-product`"
+                @update:model-value="(value) => onProductSelect(index, value ? Number(value) : null)"
+              />
             </div>
             <div class="col-span-2">
               <label v-if="index === 0" class="block text-xs font-medium text-slate-500 dark:text-slate-400 mb-1">Quantity</label>

--- a/src/pages/manufacturing/material-requisitions/__tests__/materialRequisitionProduct.test.ts
+++ b/src/pages/manufacturing/material-requisitions/__tests__/materialRequisitionProduct.test.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { applyMaterialRequisitionProductDefaults } from '../materialRequisitionLineDefaults'
+
+describe('material requisition product lines (#131)', () => {
+  it('inherits name and unit from the picked product', () => {
+    const item = { product_id: null as number | null, description: '', unit: 'unit' }
+    applyMaterialRequisitionProductDefaults(item, { id: 4, name: 'Copper Busbar', unit: 'm' })
+    expect(item.product_id).toBe(4)
+    expect(item.description).toBe('Copper Busbar')
+    expect(item.unit).toBe('m')
+  })
+
+  it('requires a product picker on the New MR form', () => {
+    const form = readFileSync(resolve(__dirname, '../MaterialRequisitionFormPage.vue'), 'utf8')
+    const validation = readFileSync(resolve(__dirname, '../../../../utils/validation.ts'), 'utf8')
+    expect(form).toContain('useProductsLookup')
+    expect(form).toContain('applyMaterialRequisitionProductDefaults')
+    expect(form).toContain('mr-item-${index}-product')
+    expect(form).toContain('product_id: item.product_id || undefined')
+    expect(validation).toContain("product_id: z.number({ required_error: 'Please select a product' })")
+  })
+})

--- a/src/pages/manufacturing/material-requisitions/materialRequisitionLineDefaults.ts
+++ b/src/pages/manufacturing/material-requisitions/materialRequisitionLineDefaults.ts
@@ -1,0 +1,20 @@
+export type MaterialProductLike = {
+  id: number
+  name: string
+  unit?: string | null
+}
+
+export type MaterialLineDraft = {
+  product_id: number | null | undefined
+  description: string
+  unit: string
+}
+
+export function applyMaterialRequisitionProductDefaults(
+  item: MaterialLineDraft,
+  product: MaterialProductLike,
+): void {
+  item.product_id = Number(product.id)
+  item.description = product.name
+  item.unit = product.unit || 'unit'
+}

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -981,7 +981,7 @@ export type ProjectRevenueFormData = z.infer<typeof projectRevenueSchema>
  */
 export const materialRequisitionItemSchema = z.object({
   work_order_item_id: z.number().optional().nullable(),
-  product_id: z.number().optional().nullable(),
+  product_id: z.number({ required_error: 'Please select a product' }).positive('Please select a product'),
   description: z.string().default(''),
   quantity_requested: z.number().min(1, 'Quantity must be at least 1').default(1),
   unit: z.string().default('unit'),


### PR DESCRIPTION
Fixes satriyop/enter365#131

## Why this PR exists
Live New Material Requisition lines were **Description / Quantity / Unit** only. Odoo MR/MO demand is **product + qty**. The backend already **requires** \`items.*.product_id\` (\`Produk harus dipilih untuk setiap item.\`), so a description-only submit 422s and never reserves the SKU.

## Root cause
SPA form never rendered a product picker. \`createEmptyItem\` had \`product_id: null\` and the payload only sent it if somehow set. Unit/description in the UI were display fields; create payload already omitted description.

## What changed
- Product picker on each requested item (catalog lookup).
- Selecting a product fills description + unit from the product master.
- Zod requires \`product_id\` (matches API).
- Payload filters to lines with a product and sends \`product_id\`, qty, unit, notes.

## How to review
1. **Helper:** \`materialRequisitionLineDefaults.ts\`
2. **Form:** \`MaterialRequisitionFormPage.vue\` Product column replaces free-text Description.
3. **Schema:** \`materialRequisitionItemSchema.product_id\` is required.
4. **Tests:** \`npm run test:run -- src/pages/manufacturing/material-requisitions/__tests__/materialRequisitionProduct.test.ts\`
5. **Live after merge:** Manufacturing → Material Requisitions → New → pick WO/warehouse → pick a product → qty/unit from product → Create. Submit without a product should fail client validation, not a generic 422.

## Out of scope
Does not explode BOM lines from the work order automatically. That is a later “from WO/BOM” helper. This PR is the missing product picker.

## Issue acceptance
- [x] MR lines pick a product; qty and unit come from the product; warehouse reservation uses that SKU