### PR TITLE
fix(pwa): bust stale SW so Laporan and form fixes actually show

### DIFF
--- a/src/components/PwaUpdatePrompt.vue
+++ b/src/components/PwaUpdatePrompt.vue
@@ -15,9 +15,15 @@ onMounted(async () => {
           immediate: true,
           onRegistered(registration) {
             if (registration) {
+              void registration.update()
+              document.addEventListener('visibilitychange', () => {
+                if (document.visibilityState === 'visible') {
+                  void registration.update()
+                }
+              })
               setInterval(() => {
                 registration.update()
-              }, 60 * 60 * 1000)
+              }, 15_000)
             }
           },
           onRegisterError(error) {

--- a/src/config/__tests__/nav.test.ts
+++ b/src/config/__tests__/nav.test.ts
@@ -12,14 +12,15 @@ function item(name: string) {
 describe('navigation permission keys', () => {
   it('uses seeder names for journals and reports', () => {
     expect(item('Journal Entries').permission).toBe('journals.view')
-    expect(item('Reports').permission).toBe('reports.financial')
+    expect(item('Laporan').permission).toBe('reports.financial')
   })
 
   it('puts Laporan under Accounting, not Finance (#129)', () => {
     const accounting = navigation.find((group) => group.label === 'Accounting')
     const finance = navigation.find((group) => group.label === 'Finance')
-    expect(accounting?.items.map((row) => row.name)).toContain('Reports')
-    expect(accounting?.items.find((row) => row.name === 'Reports')?.path).toBe('/reports')
+    expect(accounting?.items.map((row) => row.name)).toContain('Laporan')
+    expect(accounting?.items.find((row) => row.name === 'Laporan')?.path).toBe('/reports')
+    expect(finance?.items.map((row) => row.name)).not.toContain('Laporan')
     expect(finance?.items.map((row) => row.name)).not.toContain('Reports')
   })
 

--- a/src/config/nav.ts
+++ b/src/config/nav.ts
@@ -82,7 +82,7 @@ export const navigation: NavGroup[] = [
       { name: 'Budgets', path: '/accounting/budgets', icon: '📊', permission: 'budgets.view', feature: 'budgeting' },
       { name: 'Bank Reconciliation', path: '/accounting/bank-reconciliation', icon: '🏦', permission: 'journals.view', feature: 'bank_reconciliation' },
       { name: 'Recurring Templates', path: '/accounting/recurring-templates', icon: '🔄', permission: 'journals.view', feature: 'recurring' },
-      { name: 'Reports', path: '/reports', icon: '📊', permission: 'reports.financial' },
+      { name: 'Laporan', path: '/reports', icon: '📊', permission: 'reports.financial' },
     ],
   },
   {
@@ -162,6 +162,7 @@ export const POS_NAV_ID: Record<string, string> = {
   Payments: 'Pembayaran',
   Bills: 'Tagihan',
   Reports: 'Laporan',
+  Laporan: 'Laporan',
   'Company Profiles': 'Profil Perusahaan',
   Warehouses: 'Gudang',
   Roles: 'Peran',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,6 +16,9 @@ export default defineConfig({
       manifest: false, // Use our custom manifest.json in public/
       workbox: {
         cleanupOutdatedCaches: true,
+        skipWaiting: true,
+        clientsClaim: true,
+        cacheId: 'e365-spa-20260909-sw',
         // Hashed JS/CSS are precached. Do not SWR them — a waiting SW plus
         // a cached index.html is how kasir/akuntan/gudang kept running old click handlers.
         runtimeCaching: [


### PR DESCRIPTION
## Why
admin@demo.com still saw the pre-merge screens. A clean Playwright session against aidev already shows 1 Jan–31 Des, invoice product/taxes, PO Select product, Reports under Accounting. The walk is on a **cached service worker** (navigateFallback → old index.html). SW only called \`update()\` every 60 minutes. Full preset also leaves nav in English, so testers looking for **Laporan** miss **Reports**.

## What
- workbox skipWaiting + clientsClaim + cacheId bump
- SW update on register, visibility, every 15s
- Nav item renamed to Laporan

## Verify
Hard refresh once after deploy, or wait ~15s and reload. Sidebar ACCOUNTING → Laporan → /reports.