### PR TITLE
fix(spa): invoice line tax, PO pricelist fill, Laporan first in sidebar

### DIFF
--- a/src/config/__tests__/nav.test.ts
+++ b/src/config/__tests__/nav.test.ts
@@ -18,8 +18,8 @@ describe('navigation permission keys', () => {
   it('puts Laporan under Accounting, not Finance (#129)', () => {
     const accounting = navigation.find((group) => group.label === 'Accounting')
     const finance = navigation.find((group) => group.label === 'Finance')
-    expect(accounting?.items.map((row) => row.name)).toContain('Laporan')
-    expect(accounting?.items.find((row) => row.name === 'Laporan')?.path).toBe('/reports')
+    expect(accounting?.items[0]?.name).toBe('Laporan')
+    expect(accounting?.items[0]?.path).toBe('/reports')
     expect(finance?.items.map((row) => row.name)).not.toContain('Laporan')
     expect(finance?.items.map((row) => row.name)).not.toContain('Reports')
   })

--- a/src/config/nav.ts
+++ b/src/config/nav.ts
@@ -72,6 +72,7 @@ export const navigation: NavGroup[] = [
   {
     label: 'Accounting',
     items: [
+      { name: 'Laporan', path: '/reports', icon: '📊', permission: 'reports.financial' },
       { name: 'Chart of Accounts', path: '/accounting/accounts', icon: '📒', permission: 'accounts.view' },
       { name: 'Journals', path: '/accounting/journals', icon: '🗂️', permission: 'journals.view' },
       { name: 'Analytic Accounts', path: '/accounting/analytic-accounts', icon: '🎯', permission: 'journals.view' },
@@ -82,7 +83,6 @@ export const navigation: NavGroup[] = [
       { name: 'Budgets', path: '/accounting/budgets', icon: '📊', permission: 'budgets.view', feature: 'budgeting' },
       { name: 'Bank Reconciliation', path: '/accounting/bank-reconciliation', icon: '🏦', permission: 'journals.view', feature: 'bank_reconciliation' },
       { name: 'Recurring Templates', path: '/accounting/recurring-templates', icon: '🔄', permission: 'journals.view', feature: 'recurring' },
-      { name: 'Laporan', path: '/reports', icon: '📊', permission: 'reports.financial' },
     ],
   },
   {

--- a/src/layouts/AppSidebar.vue
+++ b/src/layouts/AppSidebar.vue
@@ -122,6 +122,7 @@ onBeforeUnmount(stopNavRescue)
           v-for="item in group.items"
           :key="item.path"
           :to="item.path"
+          :data-testid="item.path === '/reports' ? 'sidebar-laporan' : undefined"
           data-rescue="nav"
           class="flex items-center gap-3 px-4 py-2.5 mx-2 rounded-lg text-sm font-medium transition-colors"
           :class="[

--- a/src/pages/invoices/InvoiceFormPage.vue
+++ b/src/pages/invoices/InvoiceFormPage.vue
@@ -99,7 +99,6 @@ const [description] = defineField('description')
 const [reference] = defineField('reference')
 const [currency] = defineField('currency')
 const [exchangeRate] = defineField('exchange_rate')
-const [taxRate] = defineField('tax_rate')
 const [discountAmount] = defineField('discount_amount')
 
 // Auto-fill currency from contact's default
@@ -227,7 +226,6 @@ const onSubmit = handleSubmit(async (formValues) => {
     reference: formValues.reference || undefined,
     currency: formValues.currency || 'IDR',
     exchange_rate: formValues.exchange_rate || 1,
-    tax_rate: formValues.tax_rate,
     discount_amount: formValues.discount_amount || undefined,
     items: itemsPayload,
   }
@@ -523,19 +521,9 @@ const accountOptions = computed(() =>
                 </span>
               </div>
 
-              <!-- Tax Rate -->
-              <div class="flex items-center gap-2">
-                <span class="text-slate-600 dark:text-slate-400 text-sm w-20">Tax (%)</span>
-                <input
-                  v-model.number="taxRate"
-                  type="number"
-                  min="0"
-                  max="100"
-                  class="w-20 px-2 py-1 rounded border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100 text-sm text-right"
-                />
-                <span class="text-slate-500 dark:text-slate-400 text-sm ml-auto">
-                  {{ formatCurrency(taxAmount) }}
-                </span>
+              <div class="flex justify-between text-sm">
+                <span class="text-slate-600 dark:text-slate-400">Tax</span>
+                <span class="font-medium text-slate-900 dark:text-slate-100">{{ formatCurrency(taxAmount) }}</span>
               </div>
 
               <div class="flex justify-between text-lg font-semibold border-t border-slate-200 dark:border-slate-700 pt-2">

--- a/src/pages/invoices/__tests__/invoiceLineDefaults.test.ts
+++ b/src/pages/invoices/__tests__/invoiceLineDefaults.test.ts
@@ -65,6 +65,7 @@ describe('invoice line product defaults (#127)', () => {
     expect(form).toContain('invoice-item-${index}-tax-records')
     expect(form).toContain("useTaxRecords('sales')")
     expect(form).toContain('product_id: item.product_id || undefined')
+    expect(form).not.toContain('Tax (%)')
     expect(validation).toContain('tax_record_ids: z.array(z.number())')
   })
 })

--- a/src/pages/purchasing/purchase-orders/PurchaseOrderFormPage.vue
+++ b/src/pages/purchasing/purchase-orders/PurchaseOrderFormPage.vue
@@ -18,7 +18,9 @@ import {
 } from '@/utils/validation'
 import { setServerErrors } from '@/composables/useValidatedForm'
 import { formatCurrency, CURRENCY_OPTIONS } from '@/utils/format'
-import { priceForVendor, vendorPriceSource } from '@/utils/vendorPrice'
+import { api } from '@/api/client'
+import { applyPurchaseOrderProductDefaults, purchaseOrderPriceHint } from './poLineDefaults'
+import type { Product } from '@/api/useProducts'
 import { ArrowLeft, Plus, X } from 'lucide-vue-next'
 import {
   Button,
@@ -59,6 +61,7 @@ const {
   errors,
   handleSubmit,
   setValues,
+  setFieldValue,
   setErrors,
   validateField,
   defineField,
@@ -202,28 +205,55 @@ function handleRemoveItem(index: number) {
   }
 }
 
-function resolveLineVendorPrice(index: number) {
-  const item = form.items?.[index]
-  if (!item?.product_id || !products.value) return
-  const product = products.value.find(p => Number(p.id) === item.product_id)
-  if (!product) return
-  item.unit_price = priceForVendor(product, contactId.value ? Number(contactId.value) : null, Number(item.quantity) || 1)
+function vendorId(): number | null {
+  return contactId.value ? Number(contactId.value) : null
 }
 
-function onProductSelect(index: number, productId: number | null) {
-  if (productId && products.value) {
-    const product = products.value.find(p => Number(p.id) === productId)
-    if (product && form.items?.[index]) {
-      form.items[index].description = product.name
-      form.items[index].unit = product.unit
-      form.items[index].tax_rate = Number(product.tax_rate) || 0
-      resolveLineVendorPrice(index)
+function applyProductToLine(index: number, product: Product): void {
+  const item = form.items?.[index]
+  if (!item) return
+  applyPurchaseOrderProductDefaults(item, product, vendorId())
+  void setFieldValue(`items.${index}.description`, item.description)
+  void setFieldValue(`items.${index}.unit`, item.unit)
+  void setFieldValue(`items.${index}.tax_rate`, item.tax_rate)
+  void setFieldValue(`items.${index}.unit_price`, item.unit_price)
+}
+
+async function resolveProduct(productId: number): Promise<Product | undefined> {
+  const listed = products.value?.find(p => Number(p.id) === productId)
+  if (listed && (listed.vendor_pricelists?.length || listed.purchase_price)) {
+    if (listed.vendor_pricelists?.length) {
+      return listed
     }
+  }
+  try {
+    const response = await api.get<{ data: Product }>(`/products/${productId}`)
+    return response.data.data
+  } catch {
+    return listed
   }
 }
 
+async function resolveLineVendorPrice(index: number): Promise<void> {
+  const item = form.items?.[index]
+  if (!item?.product_id) return
+  const product = await resolveProduct(item.product_id)
+  if (!product) return
+  applyProductToLine(index, product)
+}
+
+async function onProductSelect(index: number, productId: number | null): Promise<void> {
+  const item = form.items?.[index]
+  if (!item) return
+  item.product_id = productId
+  if (!productId) return
+  const product = await resolveProduct(productId)
+  if (!product) return
+  applyProductToLine(index, product)
+}
+
 function onQuantityChange(index: number) {
-  resolveLineVendorPrice(index)
+  void resolveLineVendorPrice(index)
 }
 
 function linePriceHint(index: number): string {
@@ -231,17 +261,13 @@ function linePriceHint(index: number): string {
   if (!item?.product_id || !products.value) return ''
   const product = products.value.find(p => Number(p.id) === item.product_id)
   if (!product) return ''
-  const source = vendorPriceSource(product, contactId.value ? Number(contactId.value) : null, Number(item.quantity) || 1)
-  if (source === 'pricelist') return 'Vendor pricelist'
-  if (source === 'purchase_price') return 'Product purchase price'
-  if (source === 'selling_price') return 'Product selling price'
-  return ''
+  return purchaseOrderPriceHint(product, vendorId(), Number(item.quantity) || 1)
 }
 
 watch(contactId, (newId, oldId) => {
   if (!newId || newId === oldId) return
   if (isEditing.value && !oldId) return
-  (form.items ?? []).forEach((_, index) => resolveLineVendorPrice(index))
+  (form.items ?? []).forEach((_, index) => void resolveLineVendorPrice(index))
 })
 
 // Form submission

--- a/src/pages/purchasing/purchase-orders/__tests__/poVendorPricelist.test.ts
+++ b/src/pages/purchasing/purchase-orders/__tests__/poVendorPricelist.test.ts
@@ -1,17 +1,48 @@
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
+import { applyPurchaseOrderProductDefaults, purchaseOrderPriceHint } from '../poLineDefaults'
 
 describe('PO vendor pricelist (#128)', () => {
+  it('fills unit price from the vendor pricelist, else purchase price', () => {
+    const item = {
+      product_id: null as number | null,
+      description: '',
+      unit: 'pcs',
+      tax_rate: 11,
+      unit_price: 0,
+      quantity: 10,
+    }
+    applyPurchaseOrderProductDefaults(item, {
+      id: 9,
+      name: 'MCB 16A',
+      unit: 'pcs',
+      tax_rate: 11,
+      purchase_price: 80_000,
+      vendor_pricelists: [
+        { contact_id: 7, min_qty: 1, price: 78_000 },
+        { contact_id: 7, min_qty: 10, price: 75_000 },
+      ],
+    }, 7)
+
+    expect(item.unit_price).toBe(75_000)
+    expect(item.description).toBe('MCB 16A')
+    expect(purchaseOrderPriceHint({
+      id: 9,
+      name: 'MCB 16A',
+      purchase_price: 80_000,
+      vendor_pricelists: [{ contact_id: 7, min_qty: 10, price: 75_000 }],
+    }, 7, 10)).toContain('Vendor pricelist')
+  })
+
   it('offers catalog products after vendor is selected, not Custom as the only path', () => {
     const form = readFileSync(resolve(__dirname, '../PurchaseOrderFormPage.vue'), 'utf8')
 
-    expect(form).toContain('priceForVendor')
-    expect(form).toContain('vendorPriceSource')
+    expect(form).toContain('applyPurchaseOrderProductDefaults')
     expect(form).toContain('Select product…')
     expect(form).toContain(':disabled="!contactId"')
-    expect(form).toContain('Vendor pricelist')
     expect(form).toContain('po-item-${index}-price-source')
+    expect(form).toContain("setFieldValue(`items.${index}.unit_price`")
     expect(form).not.toMatch(/<option value="">Custom<\/option>/)
   })
 })

--- a/src/pages/purchasing/purchase-orders/poLineDefaults.ts
+++ b/src/pages/purchasing/purchase-orders/poLineDefaults.ts
@@ -1,0 +1,52 @@
+import { priceForVendor, vendorPriceSource, type VendorPricelistLine } from '@/utils/vendorPrice'
+
+export type PurchaseProductLike = {
+  id: number
+  name: string
+  unit?: string | null
+  tax_rate?: number | string | null
+  purchase_price?: number | null
+  selling_price?: number | null
+  vendor_pricelists?: VendorPricelistLine[] | null
+}
+
+export type PurchaseLineDraft = {
+  product_id: number | null
+  description: string
+  unit: string
+  tax_rate: number
+  unit_price: number
+  quantity?: number
+}
+
+export function applyPurchaseOrderProductDefaults(
+  item: PurchaseLineDraft,
+  product: PurchaseProductLike,
+  vendorId: number | null,
+): void {
+  item.product_id = Number(product.id)
+  item.description = product.name
+  item.unit = product.unit || 'pcs'
+  item.tax_rate = Number(product.tax_rate) || 0
+  const qty = Number(item.quantity) || 1
+  item.unit_price = priceForVendor(product, vendorId, qty)
+}
+
+export function purchaseOrderPriceHint(
+  product: PurchaseProductLike,
+  vendorId: number | null,
+  qty: number,
+): string {
+  const source = vendorPriceSource(product, vendorId, qty)
+  const price = priceForVendor(product, vendorId, qty)
+  if (source === 'pricelist') {
+    return `Vendor pricelist · ${price}`
+  }
+  if (source === 'purchase_price') {
+    return `Product purchase price · ${price}`
+  }
+  if (source === 'selling_price') {
+    return `Product selling price · ${price}`
+  }
+  return ''
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,7 +19,7 @@ export default defineConfig({
         cleanupOutdatedCaches: true,
         skipWaiting: true,
         clientsClaim: true,
-        cacheId: 'e365-spa-20260909-sw',
+        cacheId: 'e365-spa-20260909-c',
         // Hashed JS/CSS are precached. Do not SWR them — a waiting SW plus
         // a cached index.html is how kasir/akuntan/gudang kept running old click handlers.
         runtimeCaching: [


### PR DESCRIPTION
Follow-up after the six gaps were on aidev but still failed the admin walk.

- **#127** Remove header Tax (%). Tax amount is the sum of line sales-tax records.
- **#128** Selecting a product after vendor writes unit_price via setFieldValue from vendor pricelist (else purchase price) and labels the source.
- **#129** Laporan is the first Accounting nav item (it was last, after Recurring Templates, so the walk never scrolled to it).

Tests: nav, invoiceLineDefaults, poVendorPricelist, vendorPrice.