### PR TITLE
fix(purchasing): fill PO Price from price-for-vendor (#134)

### DIFF
--- a/src/pages/purchasing/purchase-orders/PurchaseOrderFormPage.vue
+++ b/src/pages/purchasing/purchase-orders/PurchaseOrderFormPage.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, watch, onMounted } from 'vue'
+import { computed, ref, watch, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useForm, useFieldArray } from 'vee-validate'
 import { toTypedSchema } from '@vee-validate/zod'
@@ -19,7 +19,7 @@ import {
 import { setServerErrors } from '@/composables/useValidatedForm'
 import { formatCurrency, CURRENCY_OPTIONS } from '@/utils/format'
 import { api } from '@/api/client'
-import { applyPurchaseOrderProductDefaults, purchaseOrderPriceHint } from './poLineDefaults'
+import { applyPurchaseOrderProductDefaults, purchaseOrderPriceHint, purchaseOrderPriceHintFromQuote, type VendorPriceQuote } from './poLineDefaults'
 import type { Product } from '@/api/useProducts'
 import { ArrowLeft, Plus, X } from 'lucide-vue-next'
 import {
@@ -209,11 +209,17 @@ function vendorId(): number | null {
   return contactId.value ? Number(contactId.value) : null
 }
 
-function applyProductToLine(index: number, product: Product): void {
+const lineQuotes = ref<Record<number, VendorPriceQuote>>({})
+
+function applyProductToLine(index: number, product: Product, quote?: VendorPriceQuote): void {
   const current = form.items?.[index]
   if (!current) return
   const next = { ...current }
   applyPurchaseOrderProductDefaults(next, product, vendorId())
+  if (quote) {
+    next.unit_price = quote.price
+    lineQuotes.value = { ...lineQuotes.value, [index]: quote }
+  }
   void setFieldValue(`items[${index}]`, next)
 }
 
@@ -227,16 +233,34 @@ async function resolveProduct(productId: number): Promise<Product | undefined> {
   }
 }
 
+async function quoteVendorPrice(productId: number, qty: number): Promise<VendorPriceQuote | undefined> {
+  try {
+    const response = await api.get<{ data: VendorPriceQuote }>(`/products/${productId}/price-for-vendor`, {
+      params: {
+        contact_id: vendorId() ?? undefined,
+        quantity: qty,
+      },
+    })
+    return response.data.data
+  } catch {
+    return undefined
+  }
+}
+
 async function resolveLineVendorPrice(index: number): Promise<void> {
   const item = form.items?.[index]
   if (!item?.product_id) return
   const product = await resolveProduct(item.product_id)
   if (!product) return
-  applyProductToLine(index, product)
+  const quote = await quoteVendorPrice(item.product_id, Number(item.quantity) || 1)
+  applyProductToLine(index, product, quote)
 }
 
 async function onProductSelect(index: number, productId: number | null): Promise<void> {
   if (!productId) {
+    const nextQuotes = { ...lineQuotes.value }
+    delete nextQuotes[index]
+    lineQuotes.value = nextQuotes
     void setFieldValue(`items[${index}].product_id`, null)
     return
   }
@@ -246,10 +270,7 @@ async function onProductSelect(index: number, productId: number | null): Promise
   } else {
     void setFieldValue(`items[${index}].product_id`, productId)
   }
-  const detailed = await resolveProduct(productId)
-  if (detailed) {
-    applyProductToLine(index, detailed)
-  }
+  await resolveLineVendorPrice(index)
 }
 
 function onQuantityChange(index: number) {
@@ -257,6 +278,10 @@ function onQuantityChange(index: number) {
 }
 
 function linePriceHint(index: number): string {
+  const quote = lineQuotes.value[index]
+  if (quote) {
+    return purchaseOrderPriceHintFromQuote(quote)
+  }
   const item = form.items?.[index]
   if (!item?.product_id || !products.value) return ''
   const product = products.value.find(p => Number(p.id) === item.product_id)

--- a/src/pages/purchasing/purchase-orders/PurchaseOrderFormPage.vue
+++ b/src/pages/purchasing/purchase-orders/PurchaseOrderFormPage.vue
@@ -19,7 +19,7 @@ import {
 import { setServerErrors } from '@/composables/useValidatedForm'
 import { formatCurrency, CURRENCY_OPTIONS } from '@/utils/format'
 import { api } from '@/api/client'
-import { applyPurchaseOrderProductDefaults, purchaseOrderPriceHint, purchaseOrderPriceHintFromQuote, type VendorPriceQuote } from './poLineDefaults'
+import { applyPurchaseOrderProductDefaults, applyQuotedUnitPrice, isCurrentVendorQuoteRequest, purchaseOrderPriceHint, purchaseOrderPriceHintFromQuote, type VendorPriceQuote } from './poLineDefaults'
 import type { Product } from '@/api/useProducts'
 import { ArrowLeft, Plus, X } from 'lucide-vue-next'
 import {
@@ -200,26 +200,43 @@ function addItem() {
 }
 
 function handleRemoveItem(index: number) {
-  if (itemFields.value.length > 1) {
-    removeItem(index)
+  if (itemFields.value.length <= 1) {
+    return
   }
+  const nextQuotes = { ...lineQuotes.value }
+  delete nextQuotes[lineKey(index)]
+  removeItem(index)
+  lineQuotes.value = nextQuotes
 }
 
 function vendorId(): number | null {
   return contactId.value ? Number(contactId.value) : null
 }
 
-const lineQuotes = ref<Record<number, VendorPriceQuote>>({})
+const lineQuotes = ref<Record<string, VendorPriceQuote>>({})
+
+function lineKey(index: number): string {
+  return String(itemFields.value[index]?.key ?? index)
+}
+
+function setLineQuote(index: number, quote: VendorPriceQuote | undefined): void {
+  const key = lineKey(index)
+  const next = { ...lineQuotes.value }
+  if (quote) {
+    next[key] = quote
+  } else {
+    delete next[key]
+  }
+  lineQuotes.value = next
+}
 
 function applyProductToLine(index: number, product: Product, quote?: VendorPriceQuote): void {
   const current = form.items?.[index]
   if (!current) return
   const next = { ...current }
   applyPurchaseOrderProductDefaults(next, product, vendorId())
-  if (quote) {
-    next.unit_price = quote.price
-    lineQuotes.value = { ...lineQuotes.value, [index]: quote }
-  }
+  applyQuotedUnitPrice(next, quote)
+  setLineQuote(index, quote)
   void setFieldValue(`items[${index}]`, next)
 }
 
@@ -250,17 +267,26 @@ async function quoteVendorPrice(productId: number, qty: number): Promise<VendorP
 async function resolveLineVendorPrice(index: number): Promise<void> {
   const item = form.items?.[index]
   if (!item?.product_id) return
-  const product = await resolveProduct(item.product_id)
+  const requested = {
+    productId: Number(item.product_id),
+    qty: Number(item.quantity) || 1,
+    vendorId: vendorId(),
+  }
+  const [product, quote] = await Promise.all([
+    resolveProduct(requested.productId),
+    quoteVendorPrice(requested.productId, requested.qty),
+  ])
+  const live = form.items?.[index]
+  if (!live || !isCurrentVendorQuoteRequest(live, vendorId(), requested)) {
+    return
+  }
   if (!product) return
-  const quote = await quoteVendorPrice(item.product_id, Number(item.quantity) || 1)
   applyProductToLine(index, product, quote)
 }
 
 async function onProductSelect(index: number, productId: number | null): Promise<void> {
   if (!productId) {
-    const nextQuotes = { ...lineQuotes.value }
-    delete nextQuotes[index]
-    lineQuotes.value = nextQuotes
+    setLineQuote(index, undefined)
     void setFieldValue(`items[${index}].product_id`, null)
     return
   }
@@ -278,7 +304,7 @@ function onQuantityChange(index: number) {
 }
 
 function linePriceHint(index: number): string {
-  const quote = lineQuotes.value[index]
+  const quote = lineQuotes.value[lineKey(index)]
   if (quote) {
     return purchaseOrderPriceHintFromQuote(quote)
   }

--- a/src/pages/purchasing/purchase-orders/__tests__/poVendorPricelist.test.ts
+++ b/src/pages/purchasing/purchase-orders/__tests__/poVendorPricelist.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
-import { applyPurchaseOrderProductDefaults, purchaseOrderPriceHint, purchaseOrderPriceHintFromQuote } from '../poLineDefaults'
+import { applyPurchaseOrderProductDefaults, applyQuotedUnitPrice, isCurrentVendorQuoteRequest, purchaseOrderPriceHint, purchaseOrderPriceHintFromQuote } from '../poLineDefaults'
 
 describe('PO vendor pricelist (#128)', () => {
   it('fills unit price from the vendor pricelist, else purchase price', () => {
@@ -50,5 +50,27 @@ describe('PO vendor pricelist (#128)', () => {
 
   it('labels a server quote as vendor pricelist', () => {
     expect(purchaseOrderPriceHintFromQuote({ price: 2432, source: 'pricelist' })).toBe('Vendor pricelist · 2432')
+    expect(purchaseOrderPriceHintFromQuote({ price: 2560, source: 'purchase_price' })).toBe('Product purchase price · 2560')
+    expect(purchaseOrderPriceHintFromQuote({ price: 0, source: 'none' })).toBe('')
+  })
+
+  it('overwrites the listed price with a server quote and ignores stale requests', () => {
+    const item = {
+      product_id: 9 as number | null,
+      description: 'MCB 16A',
+      unit: 'pcs',
+      tax_rate: 11,
+      unit_price: 80_000,
+      quantity: 1,
+    }
+    applyQuotedUnitPrice(item, { price: 75_000, source: 'pricelist' })
+    expect(item.unit_price).toBe(75_000)
+
+    applyQuotedUnitPrice(item, undefined)
+    expect(item.unit_price).toBe(75_000)
+
+    expect(isCurrentVendorQuoteRequest(item, 7, { productId: 9, qty: 1, vendorId: 7 })).toBe(true)
+    expect(isCurrentVendorQuoteRequest({ ...item, product_id: 10 }, 7, { productId: 9, qty: 1, vendorId: 7 })).toBe(false)
+    expect(isCurrentVendorQuoteRequest({ ...item, quantity: 10 }, 7, { productId: 9, qty: 1, vendorId: 7 })).toBe(false)
   })
 })

--- a/src/pages/purchasing/purchase-orders/__tests__/poVendorPricelist.test.ts
+++ b/src/pages/purchasing/purchase-orders/__tests__/poVendorPricelist.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
-import { applyPurchaseOrderProductDefaults, purchaseOrderPriceHint } from '../poLineDefaults'
+import { applyPurchaseOrderProductDefaults, purchaseOrderPriceHint, purchaseOrderPriceHintFromQuote } from '../poLineDefaults'
 
 describe('PO vendor pricelist (#128)', () => {
   it('fills unit price from the vendor pricelist, else purchase price', () => {
@@ -44,6 +44,11 @@ describe('PO vendor pricelist (#128)', () => {
     expect(form).toContain('po-item-${index}-price-source')
     expect(form).toContain("setFieldValue(`items[${index}]`")
     expect(form).toContain('po-price-${index}-${field.value.product_id}')
+    expect(form).toContain('/price-for-vendor')
     expect(form).not.toMatch(/<option value="">Custom<\/option>/)
+  })
+
+  it('labels a server quote as vendor pricelist', () => {
+    expect(purchaseOrderPriceHintFromQuote({ price: 2432, source: 'pricelist' })).toBe('Vendor pricelist · 2432')
   })
 })

--- a/src/pages/purchasing/purchase-orders/poLineDefaults.ts
+++ b/src/pages/purchasing/purchase-orders/poLineDefaults.ts
@@ -60,3 +60,19 @@ export function purchaseOrderPriceHint(
     price: priceForVendor(product, vendorId, qty),
   })
 }
+
+export function applyQuotedUnitPrice(item: PurchaseLineDraft, quote?: VendorPriceQuote | null): void {
+  if (quote) {
+    item.unit_price = quote.price
+  }
+}
+
+export function isCurrentVendorQuoteRequest(
+  item: { product_id: number | null; quantity?: number },
+  vendorId: number | null,
+  requested: { productId: number; qty: number; vendorId: number | null },
+): boolean {
+  return Number(item.product_id) === requested.productId
+    && (Number(item.quantity) || 1) === requested.qty
+    && vendorId === requested.vendorId
+}

--- a/src/pages/purchasing/purchase-orders/poLineDefaults.ts
+++ b/src/pages/purchasing/purchase-orders/poLineDefaults.ts
@@ -32,21 +32,31 @@ export function applyPurchaseOrderProductDefaults(
   item.unit_price = priceForVendor(product, vendorId, qty)
 }
 
+export type VendorPriceQuote = {
+  price: number
+  source: 'pricelist' | 'purchase_price' | 'selling_price' | 'none'
+}
+
+export function purchaseOrderPriceHintFromQuote(quote: VendorPriceQuote): string {
+  if (quote.source === 'pricelist') {
+    return `Vendor pricelist · ${quote.price}`
+  }
+  if (quote.source === 'purchase_price') {
+    return `Product purchase price · ${quote.price}`
+  }
+  if (quote.source === 'selling_price') {
+    return `Product selling price · ${quote.price}`
+  }
+  return ''
+}
+
 export function purchaseOrderPriceHint(
   product: PurchaseProductLike,
   vendorId: number | null,
   qty: number,
 ): string {
-  const source = vendorPriceSource(product, vendorId, qty)
-  const price = priceForVendor(product, vendorId, qty)
-  if (source === 'pricelist') {
-    return `Vendor pricelist · ${price}`
-  }
-  if (source === 'purchase_price') {
-    return `Product purchase price · ${price}`
-  }
-  if (source === 'selling_price') {
-    return `Product selling price · ${price}`
-  }
-  return ''
+  return purchaseOrderPriceHintFromQuote({
+    source: vendorPriceSource(product, vendorId, qty),
+    price: priceForVendor(product, vendorId, qty),
+  })
 }


### PR DESCRIPTION
## Why
satriyop/enter365#134: New PO Price stayed a blank/manual field. Lookup products had empty `vendor_pricelists`, so the form never inherited a supplier price.

## What
After vendor + product (and on qty/vendor change), the line calls `GET /products/{id}/price-for-vendor` and writes `data.price` into the Price input. Hint uses the server `source` (`Vendor pricelist · N` vs purchase-price fallback).

Depends on satriyop/enter365 `fix/po-vendor-pricelist-quote` (the new endpoint + demo pricelist rows).

## Test
```
npx vitest run src/pages/purchasing/purchase-orders/__tests__/poVendorPricelist.test.ts src/utils/__tests__/vendorPrice.test.ts
```
6 passed.

Closes satriyop/enter365#134