### PR TITLE
fix(sales): never silently no-op Create Invoice (#136)

### DIFF
--- a/src/pages/invoices/InvoiceFormPage.vue
+++ b/src/pages/invoices/InvoiceFormPage.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, watch, onMounted } from 'vue'
+import { computed, ref, watch, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useForm, useFieldArray } from 'vee-validate'
 import { toTypedSchema } from '@vee-validate/zod'
@@ -7,7 +7,6 @@ import {
   useInvoice,
   useCreateInvoice,
   useUpdateInvoice,
-  type CreateInvoiceItem
 } from '@/api/useInvoices'
 import { useContactsLookup } from '@/api/useContacts'
 import { useProductsLookup } from '@/api/useProducts'
@@ -17,6 +16,7 @@ import { invoiceSchema, type InvoiceFormData, type InvoiceItemFormData } from '@
 import { setServerErrors } from '@/composables/useValidatedForm'
 import { formatCurrency, toNumber, CURRENCY_OPTIONS } from '@/utils/format'
 import { applyInvoiceProductDefaults, toggleInvoiceLineTax } from './invoiceLineDefaults'
+import { firstInvoiceFormError, parseInvoiceForm } from './invoiceFormSubmit'
 import {
   Button,
   Input,
@@ -70,7 +70,6 @@ function createEmptyItem(): InvoiceItemFormData {
 const {
   values: form,
   errors,
-  handleSubmit,
   setValues,
   setFieldValue,
   setErrors,
@@ -203,38 +202,30 @@ const isSubmitting = computed(() =>
   createMutation.isPending.value || updateMutation.isPending.value
 )
 
-const onSubmit = handleSubmit(async (formValues) => {
-  const itemsPayload: CreateInvoiceItem[] = (formValues.items || [])
-    .filter(item => item.description)
-    .map(item => ({
-      product_id: item.product_id || undefined,
-      description: item.description,
-      quantity: item.quantity,
-      unit: item.unit,
-      unit_price: item.unit_price,
-      tax_rate: item.tax_rate,
-      revenue_account_id: item.revenue_account_id || undefined,
-    }))
+const submitError = ref('')
 
-  const payload = {
-    contact_id: formValues.contact_id!,
-    invoice_date: formValues.invoice_date || new Date().toISOString().split('T')[0]!,
-    due_date: formValues.due_date || new Date().toISOString().split('T')[0]!,
-    description: formValues.description || undefined,
-    reference: formValues.reference || undefined,
-    currency: formValues.currency || 'IDR',
-    exchange_rate: formValues.exchange_rate || 1,
-    discount_amount: formValues.discount_amount || undefined,
-    items: itemsPayload,
+async function onSubmit() {
+  submitError.value = ''
+  const parsed = parseInvoiceForm(form)
+  if (!parsed.ok) {
+    setErrors(parsed.errors)
+    const message = parsed.message || firstInvoiceFormError(parsed.errors)
+    submitError.value = message
+    toast.error(message)
+    return
   }
 
   try {
     if (isEditing.value && invoiceId.value) {
-      await updateMutation.mutateAsync({ id: invoiceId.value, data: payload })
+      await updateMutation.mutateAsync({ id: invoiceId.value, data: parsed.payload })
       toast.success('Invoice updated successfully')
       router.push(`/invoices/${invoiceId.value}`)
     } else {
-      const result = await createMutation.mutateAsync(payload)
+      const result = await createMutation.mutateAsync(parsed.payload)
+      if (!result?.id) {
+        toast.error('Invoice was not created')
+        return
+      }
       toast.success('Invoice created successfully')
       router.push(`/invoices/${result.id}`)
     }
@@ -245,7 +236,7 @@ const onSubmit = handleSubmit(async (formValues) => {
     }
     toast.error(response?.message || 'Failed to save invoice')
   }
-})
+}
 
 // Set default due_date to 30 days from invoice_date
 onMounted(() => {
@@ -375,8 +366,8 @@ const accountOptions = computed(() =>
           </div>
         </template>
 
-        <Alert v-if="errors.items" variant="destructive" class="mb-4">
-          {{ errors.items }}
+        <Alert v-if="submitError || errors.items" variant="destructive" class="mb-4" data-testid="invoice-form-error">
+          {{ submitError || errors.items }}
         </Alert>
 
         <div class="overflow-x-auto">
@@ -401,6 +392,7 @@ const accountOptions = computed(() =>
                       :options="productOptions"
                       placeholder="Select product…"
                       :test-id="`invoice-item-${index}-product`"
+                      :error="errors[`items.${index}.product_id`] || errors[`items[${index}].product_id`]"
                       @update:model-value="(value) => onProductSelect(index, value ? Number(value) : null)"
                     />
                   </td>
@@ -412,6 +404,12 @@ const accountOptions = computed(() =>
                       placeholder="Item description"
                       class="w-full px-2 py-1.5 rounded border border-slate-300 dark:border-slate-600 text-sm bg-white dark:bg-slate-800 text-slate-900 dark:text-slate-100 focus:ring-2 focus:ring-orange-500 focus:border-transparent"
                     />
+                    <p
+                      v-if="errors[`items.${index}.description`] || errors[`items[${index}].description`]"
+                      class="text-xs text-red-600 dark:text-red-400 mt-1"
+                    >
+                      {{ errors[`items.${index}.description`] || errors[`items[${index}].description`] }}
+                    </p>
                   </td>
                   <td class="px-3 py-2">
                     <input

--- a/src/pages/invoices/__tests__/invoiceFormSubmit.test.ts
+++ b/src/pages/invoices/__tests__/invoiceFormSubmit.test.ts
@@ -1,0 +1,154 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { invoiceCreatePayload, parseInvoiceForm } from '../invoiceFormSubmit'
+
+const liveLikeForm = {
+  contact_id: 41,
+  invoice_date: '2026-09-09',
+  due_date: '2026-10-09',
+  description: '',
+  reference: '',
+  currency: 'IDR',
+  exchange_rate: 1,
+  discount_amount: 0,
+}
+
+describe('invoice form submit (#136)', () => {
+  it('creates a payload with product_id for a product line', () => {
+    const result = parseInvoiceForm({
+      ...liveLikeForm,
+      items: [{
+        product_id: 12,
+        description: 'KT57-AIR - Air Mineral',
+        quantity: 1,
+        unit: 'btl',
+        unit_price: 10000,
+        tax_rate: 11,
+        tax_record_ids: [3],
+        taxes_manual: false,
+        revenue_account_id: 40,
+      }],
+    })
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) {
+      return
+    }
+    expect(result.payload.contact_id).toBe(41)
+    expect(result.payload.items).toHaveLength(1)
+    expect(result.payload.items[0]?.product_id).toBe(12)
+    expect(result.payload.items[0]?.description).toBe('KT57-AIR - Air Mineral')
+    expect(result.payload.items[0]?.unit_price).toBe(10000)
+  })
+
+  it('creates a draft payload for a description-only line', () => {
+    const result = parseInvoiceForm({
+      ...liveLikeForm,
+      items: [{
+        product_id: null,
+        description: 'PARITY-E2E-0909',
+        quantity: 1,
+        unit: 'pcs',
+        unit_price: 10000,
+        tax_rate: 11,
+        tax_record_ids: [],
+        taxes_manual: true,
+        revenue_account_id: null,
+      }],
+    })
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) {
+      return
+    }
+    expect(result.payload.items[0]?.product_id).toBeUndefined()
+    expect(result.payload.items[0]?.description).toBe('PARITY-E2E-0909')
+  })
+
+  it('coerces string select values so a product line still submits', () => {
+    const result = parseInvoiceForm({
+      ...liveLikeForm,
+      contact_id: '41',
+      items: [{
+        product_id: '12',
+        description: 'Air Mineral',
+        quantity: '1',
+        unit: 'pcs',
+        unit_price: '10000',
+        tax_rate: '11',
+      }],
+    })
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) {
+      return
+    }
+    expect(result.payload.contact_id).toBe(41)
+    expect(result.payload.items[0]?.product_id).toBe(12)
+    expect(result.payload.items[0]?.quantity).toBe(1)
+    expect(result.payload.items[0]?.unit_price).toBe(10000)
+  })
+
+  it('returns a visible error when there is no customer', () => {
+    const result = parseInvoiceForm({
+      ...liveLikeForm,
+      contact_id: undefined,
+      items: [{ description: 'Service', quantity: 1, unit: 'pcs', unit_price: 1000 }],
+    })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) {
+      return
+    }
+    expect(result.message).toContain('customer')
+    expect(result.errors.contact_id).toBeTruthy()
+  })
+
+  it('returns a visible items error instead of posting an empty line list', () => {
+    const normalized = parseInvoiceForm({
+      ...liveLikeForm,
+      items: [{ product_id: null, description: '   ', quantity: 1, unit: 'pcs', unit_price: 10000 }],
+    })
+    expect(normalized.ok).toBe(false)
+    if (normalized.ok) {
+      return
+    }
+    expect(normalized.message.length).toBeGreaterThan(0)
+
+    const filtered = invoiceCreatePayload({
+      contact_id: 1,
+      invoice_date: '2026-09-09',
+      due_date: '2026-10-09',
+      description: '',
+      reference: '',
+      currency: 'IDR',
+      exchange_rate: 1,
+      discount_amount: 0,
+      items: [{
+        product_id: null,
+        description: '',
+        quantity: 1,
+        unit: 'pcs',
+        unit_price: 10000,
+        tax_rate: 11,
+        tax_record_ids: [],
+        taxes_manual: false,
+        revenue_account_id: null,
+      }],
+    })
+    expect(filtered).toMatchObject({
+      ok: false,
+      errors: { items: 'At least one item with a description is required' },
+    })
+  })
+
+  it('wires New Invoice submit through parseInvoiceForm with a visible invalid path', () => {
+    const form = readFileSync(resolve(__dirname, '../InvoiceFormPage.vue'), 'utf8')
+    expect(form).toContain('parseInvoiceForm')
+    expect(form).toContain('firstInvoiceFormError')
+    expect(form).toContain('toast.error')
+    expect(form).toContain('data-testid="invoice-form-error"')
+    expect(form).not.toContain('handleSubmit(async (formValues)')
+  })
+})

--- a/src/pages/invoices/__tests__/invoiceLineDefaults.test.ts
+++ b/src/pages/invoices/__tests__/invoiceLineDefaults.test.ts
@@ -64,7 +64,7 @@ describe('invoice line product defaults (#127)', () => {
     expect(form).toContain('invoice-item-${index}-product')
     expect(form).toContain('invoice-item-${index}-tax-records')
     expect(form).toContain("useTaxRecords('sales')")
-    expect(form).toContain('product_id: item.product_id || undefined')
+    expect(form).toContain('parseInvoiceForm')
     expect(form).not.toContain('Tax (%)')
     expect(form).toContain('Tax (from line taxes)')
     expect(form).not.toContain('defineField(\'tax_rate\')')

--- a/src/pages/invoices/invoiceFormSubmit.ts
+++ b/src/pages/invoices/invoiceFormSubmit.ts
@@ -1,0 +1,152 @@
+import { invoiceSchema, type InvoiceFormData, type InvoiceItemFormData } from '@/utils/validation'
+import type { CreateInvoiceData, CreateInvoiceItem } from '@/api/useInvoices'
+
+export type InvoiceFormSubmitValues = {
+  contact_id?: number | string | null
+  invoice_date?: string
+  due_date?: string
+  description?: string
+  reference?: string
+  currency?: string
+  exchange_rate?: number | string | null
+  discount_amount?: number | string | null
+  items?: Array<{
+    product_id?: number | string | null
+    description?: string
+    quantity?: number | string | null
+    unit?: string
+    unit_price?: number | string | null
+    tax_rate?: number | string | null
+    tax_record_ids?: number[]
+    taxes_manual?: boolean
+    revenue_account_id?: number | string | null
+  }>
+}
+
+export type InvoiceFormSubmitSuccess = {
+  ok: true
+  payload: CreateInvoiceData
+}
+
+export type InvoiceFormSubmitFailure = {
+  ok: false
+  errors: Record<string, string>
+  message: string
+}
+
+export type InvoiceFormSubmitResult = InvoiceFormSubmitSuccess | InvoiceFormSubmitFailure
+
+function coerceNumber(value: unknown): number | undefined {
+  if (value === '' || value === null || value === undefined) {
+    return undefined
+  }
+  const n = typeof value === 'number' ? value : Number(value)
+  return Number.isFinite(n) ? n : undefined
+}
+
+function coerceId(value: unknown): number | null {
+  const n = coerceNumber(value)
+  if (n === undefined || n <= 0) {
+    return null
+  }
+  return n
+}
+
+export function firstInvoiceFormError(errors: Record<string, unknown>): string {
+  for (const value of Object.values(errors)) {
+    if (typeof value === 'string' && value.trim() !== '') {
+      return value
+    }
+    if (Array.isArray(value) && typeof value[0] === 'string' && value[0].trim() !== '') {
+      return value[0]
+    }
+  }
+  return 'Please fix validation errors'
+}
+
+export function normalizeInvoiceForm(values: InvoiceFormSubmitValues): InvoiceFormData {
+  const items: InvoiceItemFormData[] = (values.items ?? []).map((item) => ({
+    product_id: coerceId(item.product_id),
+    description: (item.description ?? '').trim(),
+    quantity: coerceNumber(item.quantity) ?? 1,
+    unit: item.unit || 'pcs',
+    unit_price: coerceNumber(item.unit_price) ?? 0,
+    tax_rate: coerceNumber(item.tax_rate) ?? 0,
+    tax_record_ids: item.tax_record_ids ?? [],
+    taxes_manual: item.taxes_manual ?? false,
+    revenue_account_id: coerceId(item.revenue_account_id),
+  }))
+
+  return {
+    contact_id: coerceId(values.contact_id) ?? (undefined as unknown as number),
+    invoice_date: values.invoice_date ?? '',
+    due_date: values.due_date ?? '',
+    description: values.description ?? '',
+    reference: values.reference ?? '',
+    currency: values.currency || 'IDR',
+    exchange_rate: coerceNumber(values.exchange_rate) ?? 1,
+    discount_amount: coerceNumber(values.discount_amount) ?? 0,
+    items,
+  }
+}
+
+export function invoiceCreatePayload(form: InvoiceFormData): CreateInvoiceData | InvoiceFormSubmitFailure {
+  const itemsPayload: CreateInvoiceItem[] = (form.items || [])
+    .filter((item) => item.description.trim() !== '')
+    .map((item) => ({
+      product_id: item.product_id || undefined,
+      description: item.description,
+      quantity: item.quantity,
+      unit: item.unit,
+      unit_price: item.unit_price,
+      tax_rate: item.tax_rate,
+      revenue_account_id: item.revenue_account_id || undefined,
+    }))
+
+  if (itemsPayload.length === 0) {
+    return {
+      ok: false,
+      errors: { items: 'At least one item with a description is required' },
+      message: 'At least one item with a description is required',
+    }
+  }
+
+  return {
+    contact_id: form.contact_id,
+    invoice_date: form.invoice_date,
+    due_date: form.due_date,
+    description: form.description || undefined,
+    reference: form.reference || undefined,
+    currency: form.currency || 'IDR',
+    exchange_rate: form.exchange_rate || 1,
+    discount_amount: form.discount_amount || undefined,
+    items: itemsPayload,
+  }
+}
+
+export function parseInvoiceForm(values: InvoiceFormSubmitValues): InvoiceFormSubmitResult {
+  const normalized = normalizeInvoiceForm(values)
+  const parsed = invoiceSchema.safeParse(normalized)
+
+  if (!parsed.success) {
+    const errors: Record<string, string> = {}
+    for (const issue of parsed.error.issues) {
+      const path = issue.path.length > 0 ? issue.path.join('.') : 'form'
+      if (!errors[path]) {
+        errors[path] = issue.message
+      }
+    }
+    return {
+      ok: false,
+      errors,
+      message: firstInvoiceFormError(errors),
+    }
+  }
+
+  const payload = invoiceCreatePayload(parsed.data)
+  if ('ok' in payload && payload.ok === false) {
+    return payload
+  }
+
+  return { ok: true, payload }
+}

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -312,14 +312,13 @@ export const invoiceItemSchema = z.object({
  * Invoice form schema
  */
 export const invoiceSchema = z.object({
-  contact_id: z.number({ required_error: 'Please select a customer' }).positive('Please select a customer'),
+  contact_id: z.number({ required_error: 'Please select a customer', invalid_type_error: 'Please select a customer' }).positive('Please select a customer'),
   invoice_date: requiredDate('Invoice date'),
   due_date: requiredDate('Due date'),
   description: descriptionSchema,
   reference: referenceSchema,
   currency: z.string().default('IDR'),
   exchange_rate: z.number().min(0).default(1),
-  tax_rate: percentageSchema.default(11),
   discount_amount: currencySchema.default(0),
   receivable_account_id: z.number().optional().nullable(),
   items: z.array(invoiceItemSchema).min(1, 'At least one item is required'),


### PR DESCRIPTION
Closes satriyop/enter365#136

Create Invoice stayed on `/invoices/new` with no toast when vee-validate `handleSubmit` rejected the form (and nested item errors were not shown).

## What
- Submit goes through `parseInvoiceForm` — valid product line or description-only line POSTs; anything else toasts + shows `invoice-form-error`
- Coerce string Select values so a picked product still submits
- Drop unused header `tax_rate` from `invoiceSchema` (the Tax (%) field is gone)

Companion API tests: satriyop/enter365 branch `fix/136-invoice-create-silent-noop`.