### PR TITLE
fix(purchasing): show PO amount from total_amount (#137)

### DIFF
--- a/src/pages/purchasing/purchase-orders/PurchaseOrderDetailPage.vue
+++ b/src/pages/purchasing/purchase-orders/PurchaseOrderDetailPage.vue
@@ -16,6 +16,7 @@ import { useCreateGRNFromPO, type CreateFromPOData } from '@/api/useGoodsReceipt
 import { useWarehousesLookup } from '@/api/useInventory'
 import { getErrorMessage } from '@/api/client'
 import { formatCurrency, formatDate } from '@/utils/format'
+import { purchaseOrderAmount } from './purchaseOrderAmount'
 import {
   ArrowLeft,
   Edit,
@@ -515,7 +516,7 @@ const itemColumns: ResponsiveColumn[] = [
               <hr class="border-slate-200 dark:border-slate-700" />
               <div class="flex justify-between">
                 <dt class="font-semibold text-slate-900 dark:text-slate-100">Total</dt>
-                <dd class="font-bold text-lg text-primary-600 dark:text-primary-400">{{ formatCurrency(po.total) }}</dd>
+                <dd class="font-bold text-lg text-primary-600 dark:text-primary-400" data-testid="po-detail-total">{{ formatCurrency(purchaseOrderAmount(po)) }}</dd>
               </div>
               <div v-if="po.currency !== 'IDR'" class="flex justify-between text-sm" data-testid="po-base-currency-total">
                 <dt class="text-slate-500 dark:text-slate-400">Base Currency</dt>

--- a/src/pages/purchasing/purchase-orders/PurchaseOrderListPage.vue
+++ b/src/pages/purchasing/purchase-orders/PurchaseOrderListPage.vue
@@ -11,6 +11,7 @@ import {
 } from '@/api/usePurchaseOrders'
 import { useResourceList } from '@/composables/useResourceList'
 import { formatCurrency, formatDate } from '@/utils/format'
+import { purchaseOrderAmount } from './purchaseOrderAmount'
 import {
   Plus,
   Package,
@@ -71,7 +72,7 @@ function handleStatusChange(value: string | number | null) {
 const columns: ResponsiveColumn[] = [
   { key: 'po_number', label: 'PO Number', mobilePriority: 1 },
   { key: 'contact', label: 'Vendor', mobilePriority: 2 },
-  { key: 'total', label: 'Amount', align: 'right', mobilePriority: 3, format: (v) => formatCurrency(v as number) },
+  { key: 'total_amount', label: 'Amount', align: 'right', mobilePriority: 3, format: (v) => formatCurrency(v as number) },
   { key: 'status', label: 'Status', showInMobile: false },
   { key: 'expected_date', label: 'Expected', showInMobile: false, format: (v) => v ? formatDate(v as string) : '-' },
   { key: 'actions', label: '', showInMobile: false },
@@ -234,6 +235,10 @@ function viewPO(item: Record<string, unknown>) {
         <template #cell-contact="{ item }">
           <div class="font-medium text-slate-900 dark:text-slate-100">{{ (item as PurchaseOrder).contact?.name || '-' }}</div>
           <div v-if="(item as PurchaseOrder).subject" class="text-sm text-slate-500 dark:text-slate-400">{{ (item as PurchaseOrder).subject }}</div>
+        </template>
+
+        <template #cell-total_amount="{ item }">
+          <span data-testid="po-list-amount">{{ formatCurrency(purchaseOrderAmount(item as PurchaseOrder)) }}</span>
         </template>
 
         <!-- Status -->

--- a/src/pages/purchasing/purchase-orders/__tests__/purchaseOrderAmount.test.ts
+++ b/src/pages/purchasing/purchase-orders/__tests__/purchaseOrderAmount.test.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { purchaseOrderAmount } from '../purchaseOrderAmount'
+
+describe('PO list/detail amount (#137)', () => {
+  it('reads total_amount from the API resource, not a missing total field', () => {
+    expect(purchaseOrderAmount({ total_amount: 2432, total: 0 })).toBe(2432)
+    expect(purchaseOrderAmount({ total_amount: 2700 })).toBe(2700)
+    expect(purchaseOrderAmount({ total: 2700 })).toBe(2700)
+    expect(purchaseOrderAmount({})).toBe(0)
+  })
+
+  it('wires list AMOUNT and detail Total to total_amount', () => {
+    const list = readFileSync(resolve(__dirname, '../PurchaseOrderListPage.vue'), 'utf8')
+    const detail = readFileSync(resolve(__dirname, '../PurchaseOrderDetailPage.vue'), 'utf8')
+
+    expect(list).toContain("key: 'total_amount'")
+    expect(list).toContain('purchaseOrderAmount')
+    expect(list).not.toContain("key: 'total'")
+    expect(detail).toContain('purchaseOrderAmount(po)')
+    expect(detail).not.toContain('formatCurrency(po.total)')
+  })
+})

--- a/src/pages/purchasing/purchase-orders/purchaseOrderAmount.ts
+++ b/src/pages/purchasing/purchase-orders/purchaseOrderAmount.ts
@@ -1,0 +1,15 @@
+import { toNumber, type NumericValue } from '@/utils/format'
+
+/**
+ * List/detail AMOUNT for a purchase order.
+ * The API field is `total_amount`; some clients historically read `total`.
+ */
+export function purchaseOrderAmount(po: {
+  total_amount?: NumericValue
+  total?: NumericValue
+}): number {
+  if (po.total_amount != null && po.total_amount !== '') {
+    return toNumber(po.total_amount)
+  }
+  return toNumber(po.total)
+}


### PR DESCRIPTION
Closes satriyop/enter365#137

List AMOUNT and detail Total used `po.total`. The resource exposes `total_amount`, so a PO with priced lines showed Rp 0 after create.

## What
- `purchaseOrderAmount()` reads `total_amount` (fallback `total`)
- List column key `total_amount`; detail Total uses the helper

Companion API persistence test: satriyop/enter365 `fix/137-po-list-amount-zero`.