### PR TITLE
fix(purchasing): PO amount from total_amount or subtotal+tax (#137)

### DIFF
--- a/src/pages/purchasing/purchase-orders/PurchaseOrderDetailPage.vue
+++ b/src/pages/purchasing/purchase-orders/PurchaseOrderDetailPage.vue
@@ -16,7 +16,7 @@ import { useCreateGRNFromPO, type CreateFromPOData } from '@/api/useGoodsReceipt
 import { useWarehousesLookup } from '@/api/useInventory'
 import { getErrorMessage } from '@/api/client'
 import { formatCurrency, formatDate } from '@/utils/format'
-import { purchaseOrderAmount } from './purchaseOrderAmount'
+import { purchaseOrderAmount, purchaseOrderLineAmount } from './purchaseOrderAmount'
 import {
   ArrowLeft,
   Edit,
@@ -44,6 +44,8 @@ const poId = computed(() => Number(route.params.id))
 
 // Data fetching
 const { data: po, isLoading, error } = usePurchaseOrder(poId)
+
+const headerTotal = computed(() => purchaseOrderAmount(po.value))
 
 // Mutations
 const submitMutation = useSubmitPurchaseOrder()
@@ -450,7 +452,7 @@ const itemColumns: ResponsiveColumn[] = [
 
               <!-- Line Total -->
               <template #cell-line_total="{ item }">
-                <span class="font-medium text-slate-900 dark:text-slate-100">{{ formatCurrency((item as any).line_total) }}</span>
+                <span class="font-medium text-slate-900 dark:text-slate-100" data-testid="po-line-total">{{ formatCurrency(purchaseOrderLineAmount(item)) }}</span>
               </template>
 
               <!-- Mobile title -->
@@ -516,7 +518,7 @@ const itemColumns: ResponsiveColumn[] = [
               <hr class="border-slate-200 dark:border-slate-700" />
               <div class="flex justify-between">
                 <dt class="font-semibold text-slate-900 dark:text-slate-100">Total</dt>
-                <dd class="font-bold text-lg text-primary-600 dark:text-primary-400" data-testid="po-detail-total">{{ formatCurrency(purchaseOrderAmount(po)) }}</dd>
+                <dd class="font-bold text-lg text-primary-600 dark:text-primary-400" data-testid="po-detail-total">{{ formatCurrency(headerTotal) }}</dd>
               </div>
               <div v-if="po.currency !== 'IDR'" class="flex justify-between text-sm" data-testid="po-base-currency-total">
                 <dt class="text-slate-500 dark:text-slate-400">Base Currency</dt>

--- a/src/pages/purchasing/purchase-orders/PurchaseOrderListPage.vue
+++ b/src/pages/purchasing/purchase-orders/PurchaseOrderListPage.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { computed } from 'vue'
 import { useRouter } from 'vue-router'
 import {
   usePurchaseOrders,
@@ -68,11 +69,18 @@ function handleStatusChange(value: string | number | null) {
   updateFilter('status', value === '' ? undefined : (value as PurchaseOrderStatus))
 }
 
+const poListRows = computed(() =>
+  purchaseOrders.value.map((po) => ({
+    ...po,
+    total_amount: purchaseOrderAmount(po),
+  })),
+)
+
 // Table columns
 const columns: ResponsiveColumn[] = [
   { key: 'po_number', label: 'PO Number', mobilePriority: 1 },
   { key: 'contact', label: 'Vendor', mobilePriority: 2 },
-  { key: 'total_amount', label: 'Amount', align: 'right', mobilePriority: 3, format: (v) => formatCurrency(v as number) },
+  { key: 'total_amount', label: 'Amount', align: 'right', mobilePriority: 3, format: (v) => formatCurrency(purchaseOrderAmount({ total_amount: v })) },
   { key: 'status', label: 'Status', showInMobile: false },
   { key: 'expected_date', label: 'Expected', showInMobile: false, format: (v) => v ? formatDate(v as string) : '-' },
   { key: 'actions', label: '', showInMobile: false },
@@ -217,7 +225,7 @@ function viewPO(item: Record<string, unknown>) {
     <!-- Table -->
     <Card v-else :padding="false">
       <ResponsiveTable
-        :items="purchaseOrders"
+        :items="poListRows"
         :columns="columns"
         :loading="isLoading"
         title-field="full_number"

--- a/src/pages/purchasing/purchase-orders/__tests__/purchaseOrderAmount.test.ts
+++ b/src/pages/purchasing/purchase-orders/__tests__/purchaseOrderAmount.test.ts
@@ -1,24 +1,47 @@
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
-import { purchaseOrderAmount } from '../purchaseOrderAmount'
+import { purchaseOrderAmount, purchaseOrderLineAmount } from '../purchaseOrderAmount'
 
 describe('PO list/detail amount (#137)', () => {
   it('reads total_amount from the API resource, not a missing total field', () => {
-    expect(purchaseOrderAmount({ total_amount: 2432, total: 0 })).toBe(2432)
+    expect(purchaseOrderAmount({ total_amount: 2700, total: 0 })).toBe(2700)
     expect(purchaseOrderAmount({ total_amount: 2700 })).toBe(2700)
     expect(purchaseOrderAmount({ total: 2700 })).toBe(2700)
-    expect(purchaseOrderAmount({})).toBe(0)
   })
 
-  it('wires list AMOUNT and detail Total to total_amount', () => {
+  it('falls back to subtotal + tax when total_amount is 0', () => {
+    expect(purchaseOrderAmount({
+      total_amount: 0,
+      total: 0,
+      subtotal: 2432,
+      tax_amount: 268,
+      discount_amount: 0,
+    })).toBe(2700)
+  })
+
+  it('unwraps a vue-query style ref so template function calls still total', () => {
+    expect(purchaseOrderAmount({
+      value: { total_amount: 0, subtotal: 2432, tax_amount: 268, po_number: 'PO-202609-0009' },
+    })).toBe(2700)
+  })
+
+  it('reads line Total from total_amount or subtotal, not missing line_total', () => {
+    expect(purchaseOrderLineAmount({ line_total: null, subtotal: 2432, tax_amount: 268, total_amount: 2700 })).toBe(2700)
+    expect(purchaseOrderLineAmount({ subtotal: 2432, tax_amount: 268 })).toBe(2700)
+    expect(purchaseOrderLineAmount({ quantity: 1, unit_price: 2432 })).toBe(2432)
+  })
+
+  it('wires list AMOUNT and detail/line Total through the helpers', () => {
     const list = readFileSync(resolve(__dirname, '../PurchaseOrderListPage.vue'), 'utf8')
     const detail = readFileSync(resolve(__dirname, '../PurchaseOrderDetailPage.vue'), 'utf8')
 
     expect(list).toContain("key: 'total_amount'")
     expect(list).toContain('purchaseOrderAmount')
-    expect(list).not.toContain("key: 'total'")
-    expect(detail).toContain('purchaseOrderAmount(po)')
+    expect(list).toContain('poListRows')
+    expect(detail).toContain('headerTotal')
+    expect(detail).toContain('purchaseOrderLineAmount')
     expect(detail).not.toContain('formatCurrency(po.total)')
+    expect(detail).not.toContain('item.line_total')
   })
 })

--- a/src/pages/purchasing/purchase-orders/purchaseOrderAmount.ts
+++ b/src/pages/purchasing/purchase-orders/purchaseOrderAmount.ts
@@ -1,15 +1,49 @@
 import { toNumber, type NumericValue } from '@/utils/format'
 
-/**
- * List/detail AMOUNT for a purchase order.
- * The API field is `total_amount`; some clients historically read `total`.
- */
-export function purchaseOrderAmount(po: {
-  total_amount?: NumericValue
-  total?: NumericValue
-}): number {
-  if (po.total_amount != null && po.total_amount !== '') {
-    return toNumber(po.total_amount)
+type AmountRecord = Record<string, unknown>
+
+function unwrapRecord(value: unknown): AmountRecord {
+  if (value == null || typeof value !== 'object') {
+    return {}
   }
-  return toNumber(po.total)
+  const record = value as AmountRecord
+  const inner = record.value
+  if (inner && typeof inner === 'object' && !Array.isArray(inner) && ('po_number' in inner || 'subtotal' in inner || 'unit_price' in inner || 'total_amount' in inner)) {
+    return inner as AmountRecord
+  }
+  return record
+}
+
+function amount(value: unknown): number {
+  return toNumber(value as NumericValue)
+}
+
+/**
+ * List/detail AMOUNT. Prefer persisted `total_amount`, then `total`,
+ * then subtotal + tax − discount (the live API has the parts even when
+ * a client still reads a missing `total`).
+ */
+export function purchaseOrderAmount(po: unknown): number {
+  const row = unwrapRecord(po)
+  const stored = amount(row.total_amount) || amount(row.total)
+  if (stored > 0) {
+    return stored
+  }
+  return amount(row.subtotal) + amount(row.tax_amount) - amount(row.discount_amount)
+}
+
+/**
+ * Line Total. API lines expose `subtotal` / `total_amount`, not `line_total`.
+ */
+export function purchaseOrderLineAmount(line: unknown): number {
+  const row = unwrapRecord(line)
+  const stored = amount(row.total_amount) || amount(row.line_total)
+  if (stored > 0) {
+    return stored
+  }
+  const net = amount(row.subtotal)
+  if (net > 0) {
+    return net + amount(row.tax_amount)
+  }
+  return amount(row.quantity) * amount(row.unit_price)
 }


### PR DESCRIPTION
Closes satriyop/enter365#137

Live: list AMOUNT, detail Total, and line Total stayed Rp 0 while Subtotal/Tax were correct and API `total_amount` was 2700.

## What
- `purchaseOrderAmount()`: `total_amount` / `total`, else subtotal + tax − discount; unwraps vue-query refs
- `purchaseOrderLineAmount()`: item `total_amount` / `line_total` / subtotal+tax
- List remaps rows so the Amount column cannot stay 0 when lines are priced
- Detail Total uses a computed `headerTotal` from `po.value`

Companion API aliases: satriyop/enter365 `fix/137-po-amount-display`.