### PR TITLE
feat(accounting): Credit Notes and Vendor Refunds (#141)

### DIFF
--- a/src/config/nav.ts
+++ b/src/config/nav.ts
@@ -74,6 +74,8 @@ export const navigation: NavGroup[] = [
     label: 'Accounting',
     items: [
       { name: 'Laporan', path: '/reports', icon: '📊', permission: 'reports.financial' },
+      { name: 'Credit Notes', path: '/accounting/credit-notes', icon: '🧾', permission: 'sales_returns.view', feature: 'sales_returns' },
+      { name: 'Vendor Refunds', path: '/accounting/vendor-refunds', icon: '📤', permission: 'purchase_returns.view', feature: 'purchase_returns' },
       { name: 'Chart of Accounts', path: '/accounting/accounts', icon: '📒', permission: 'accounts.view' },
       { name: 'Journals', path: '/accounting/journals', icon: '🗂️', permission: 'journals.view' },
       { name: 'Analytic Accounts', path: '/accounting/analytic-accounts', icon: '🎯', permission: 'journals.view' },
@@ -160,6 +162,8 @@ export const POS_NAV_ID: Record<string, string> = {
   'Journal Entries': 'Jurnal',
   'Fiscal Periods': 'Periode Fiskal',
   'Bank Reconciliation': 'Rekonsiliasi',
+  'Credit Notes': 'Nota Kredit',
+  'Vendor Refunds': 'Refund Vendor',
   Payments: 'Pembayaran',
   Bills: 'Tagihan',
   Reports: 'Laporan',

--- a/src/layouts/AppSidebar.vue
+++ b/src/layouts/AppSidebar.vue
@@ -122,7 +122,13 @@ onBeforeUnmount(stopNavRescue)
           v-for="item in group.items"
           :key="item.path"
           :to="item.path"
-          :data-testid="item.path === '/reports' ? `sidebar-laporan-${group.label.toLowerCase()}` : undefined"
+          :data-testid="item.path === '/reports'
+            ? `sidebar-laporan-${group.label.toLowerCase()}`
+            : item.path === '/accounting/credit-notes'
+              ? 'sidebar-credit-notes'
+              : item.path === '/accounting/vendor-refunds'
+                ? 'sidebar-vendor-refunds'
+                : undefined"
           data-rescue="nav"
           class="flex items-center gap-3 px-4 py-2.5 mx-2 rounded-lg text-sm font-medium transition-colors"
           :class="[

--- a/src/pages/accounting/__tests__/creditDocuments.test.ts
+++ b/src/pages/accounting/__tests__/creditDocuments.test.ts
@@ -1,0 +1,45 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { customerCreditNoteJourney, vendorRefundJourney } from '../creditDocuments'
+import { flattenNav, navigation } from '@/config/nav'
+
+describe('accounting credit notes and vendor refunds (#141)', () => {
+  it('labels the accounting journeys as Credit Notes and Vendor Refunds', () => {
+    const notes = customerCreditNoteJourney('/accounting/credit-notes')
+    expect(notes.listTitle).toBe('Credit Notes')
+    expect(notes.newPath).toBe('/accounting/credit-notes/new')
+    expect(notes.detailPath(9)).toBe('/accounting/credit-notes/9')
+
+    const refunds = vendorRefundJourney('/accounting/vendor-refunds/new')
+    expect(refunds.listTitle).toBe('Vendor Refunds')
+    expect(refunds.newPath).toBe('/accounting/vendor-refunds/new')
+    expect(refunds.detailPath(3)).toBe('/accounting/vendor-refunds/3')
+  })
+
+  it('keeps warehouse sales/purchase return labels on the original paths', () => {
+    expect(customerCreditNoteJourney('/sales/sales-returns').listTitle).toBe('Sales Returns')
+    expect(vendorRefundJourney('/purchasing/purchase-returns').listTitle).toBe('Purchase Returns')
+  })
+
+  it('pins Credit Notes and Vendor Refunds under Accounting in the sidebar', () => {
+    const accounting = navigation.find((group) => group.label === 'Accounting')
+    const names = accounting?.items.map((row) => row.name) ?? []
+    expect(names).toContain('Credit Notes')
+    expect(names).toContain('Vendor Refunds')
+    expect(flattenNav().find((row) => row.name === 'Credit Notes')?.path).toBe('/accounting/credit-notes')
+    expect(flattenNav().find((row) => row.name === 'Vendor Refunds')?.path).toBe('/accounting/vendor-refunds')
+  })
+
+  it('registers accounting routes so candidate URLs are not 404', () => {
+    const router = readFileSync(resolve(__dirname, '../../../router/index.ts'), 'utf8')
+    expect(router).toContain("path: 'accounting/credit-notes'")
+    expect(router).toContain("path: 'accounting/credit-notes/new'")
+    expect(router).toContain("path: 'accounting/vendor-refunds'")
+    expect(router).toContain("path: 'accounting/vendor-refunds/new'")
+    expect(router).toContain("path: 'credit-notes'")
+    expect(router).toContain("path: 'vendor-refunds'")
+    expect(router).toContain("prefix: '/credit-notes'")
+    expect(router).toContain("prefix: '/vendor-refunds'")
+  })
+})

--- a/src/pages/accounting/creditDocuments.ts
+++ b/src/pages/accounting/creditDocuments.ts
@@ -1,0 +1,95 @@
+export type CreditDocumentCopy = {
+  listTitle: string
+  listHint: string
+  newTitle: string
+  editTitle: string
+  createCta: string
+  emptyTitle: string
+  emptyHint: string
+  listPath: string
+  newPath: string
+  detailPath: (id: number | string) => string
+  editPath: (id: number | string) => string
+  saveCreate: string
+  saveUpdate: string
+}
+
+export function isCustomerCreditNotePath(path: string): boolean {
+  return path.includes('/credit-notes')
+}
+
+export function isVendorRefundPath(path: string): boolean {
+  return path.includes('/vendor-refunds')
+}
+
+export function customerCreditNoteJourney(path: string): CreditDocumentCopy {
+  if (isCustomerCreditNotePath(path)) {
+    return {
+      listTitle: 'Credit Notes',
+      listHint: 'Customer credit notes that reverse accounts receivable',
+      newTitle: 'New Credit Note',
+      editTitle: 'Edit Credit Note',
+      createCta: 'New Credit Note',
+      emptyTitle: 'No credit notes found',
+      emptyHint: 'Create a credit note against a customer invoice',
+      listPath: '/accounting/credit-notes',
+      newPath: '/accounting/credit-notes/new',
+      detailPath: (id) => `/accounting/credit-notes/${id}`,
+      editPath: (id) => `/accounting/credit-notes/${id}/edit`,
+      saveCreate: 'Create Credit Note',
+      saveUpdate: 'Update Credit Note',
+    }
+  }
+
+  return {
+    listTitle: 'Sales Returns',
+    listHint: 'Manage returns from customers',
+    newTitle: 'New Sales Return',
+    editTitle: 'Edit Sales Return',
+    createCta: 'New Return',
+    emptyTitle: 'No sales returns found',
+    emptyHint: 'Create a return when a customer returns goods',
+    listPath: '/sales/sales-returns',
+    newPath: '/sales/sales-returns/new',
+    detailPath: (id) => `/sales/sales-returns/${id}`,
+    editPath: (id) => `/sales/sales-returns/${id}/edit`,
+    saveCreate: 'Create Sales Return',
+    saveUpdate: 'Update Sales Return',
+  }
+}
+
+export function vendorRefundJourney(path: string): CreditDocumentCopy {
+  if (isVendorRefundPath(path)) {
+    return {
+      listTitle: 'Vendor Refunds',
+      listHint: 'Vendor refunds that reverse accounts payable',
+      newTitle: 'New Vendor Refund',
+      editTitle: 'Edit Vendor Refund',
+      createCta: 'New Vendor Refund',
+      emptyTitle: 'No vendor refunds found',
+      emptyHint: 'Create a refund against a vendor bill',
+      listPath: '/accounting/vendor-refunds',
+      newPath: '/accounting/vendor-refunds/new',
+      detailPath: (id) => `/accounting/vendor-refunds/${id}`,
+      editPath: (id) => `/accounting/vendor-refunds/${id}/edit`,
+      saveCreate: 'Create Vendor Refund',
+      saveUpdate: 'Update Vendor Refund',
+    }
+  }
+
+  return {
+    listTitle: 'Purchase Returns',
+    listHint: 'Manage returns to vendors',
+    newTitle: 'New Purchase Return',
+    editTitle: 'Edit Purchase Return',
+    createCta: 'New Return',
+    emptyTitle: 'No purchase returns found',
+    emptyHint: 'Create a return when you need to send goods back to a vendor',
+    listPath: '/purchasing/purchase-returns',
+    newPath: '/purchasing/purchase-returns/new',
+    detailPath: (id) => `/purchasing/purchase-returns/${id}`,
+    editPath: (id) => `/purchasing/purchase-returns/${id}/edit`,
+    saveCreate: 'Create Purchase Return',
+    saveUpdate: 'Update Purchase Return',
+  }
+}

--- a/src/pages/invoices/InvoiceDetailPage.vue
+++ b/src/pages/invoices/InvoiceDetailPage.vue
@@ -262,8 +262,8 @@ async function handleCreateSR() {
       data: payload,
     })
     showCreateSRModal.value = false
-    toast.success('Sales return created')
-    router.push(`/sales/sales-returns/${newSR.id}`)
+    toast.success('Credit note created')
+    router.push(`/accounting/credit-notes/${newSR.id}`)
   } catch {
     toast.error('Failed to create sales return')
   }
@@ -595,7 +595,7 @@ const itemColumns: ResponsiveColumn[] = [
                 @click="showCreateSRModal = true"
               >
                 <RotateCcw class="w-4 h-4 mr-2" />
-                Create Sales Return
+                Create Credit Note
               </Button>
               <Button
                 v-if="canSend"
@@ -801,9 +801,9 @@ const itemColumns: ResponsiveColumn[] = [
     </Modal>
 
     <!-- Create Sales Return Modal -->
-    <Modal :open="showCreateSRModal" title="Create Sales Return" @update:open="showCreateSRModal = $event">
+    <Modal :open="showCreateSRModal" title="Create Credit Note" @update:open="showCreateSRModal = $event">
       <p class="text-slate-600 dark:text-slate-400 mb-4">
-        Create a sales return from this invoice. Items will be copied automatically.
+        Create a customer credit note from this invoice. Items will be copied automatically.
       </p>
       <div class="space-y-4">
         <FormField label="Return Date">
@@ -841,7 +841,7 @@ const itemColumns: ResponsiveColumn[] = [
           @click="handleCreateSR"
         >
           <RotateCcw class="w-4 h-4 mr-2" />
-          Create Sales Return
+          Create Credit Note
         </Button>
       </template>
     </Modal>

--- a/src/pages/purchasing/purchase-returns/PurchaseReturnDetailPage.vue
+++ b/src/pages/purchasing/purchase-returns/PurchaseReturnDetailPage.vue
@@ -14,6 +14,7 @@ import {
 } from '@/api/usePurchaseReturns'
 import { getErrorMessage } from '@/api/client'
 import { formatCurrency, formatDate } from '@/utils/format'
+import { vendorRefundJourney } from '@/pages/accounting/creditDocuments'
 import {
   ArrowLeft,
   Edit,
@@ -30,6 +31,7 @@ import { Button, Badge, Card, Modal, PageSkeleton, useToast, ResponsiveTable, ty
 const route = useRoute()
 const router = useRouter()
 const toast = useToast()
+const copy = computed(() => vendorRefundJourney(route.path))
 
 const returnId = computed(() => Number(route.params.id))
 
@@ -106,7 +108,7 @@ async function handleDelete() {
     await deleteMutation.mutateAsync(returnId.value)
     showDeleteModal.value = false
     toast.success('Return deleted')
-    router.push('/purchasing/purchase-returns')
+    router.push(copy.value.listPath)
   } catch (err) {
     toast.error(getErrorMessage(err, 'Failed to delete return'))
   }
@@ -144,9 +146,9 @@ const itemColumns: ResponsiveColumn[] = [
     <template v-else-if="purchaseReturn">
       <!-- Breadcrumb -->
       <div class="flex items-center gap-2 text-sm text-slate-500 dark:text-slate-400 mb-4">
-        <RouterLink to="/purchasing/purchase-returns" class="hover:text-slate-700 dark:hover:text-slate-300 flex items-center gap-1">
+        <RouterLink :to="copy.listPath" class="hover:text-slate-700 dark:hover:text-slate-300 flex items-center gap-1">
           <ArrowLeft class="w-4 h-4" />
-          Purchase Returns
+          {{ copy.listTitle }}
         </RouterLink>
         <span>/</span>
         <span class="text-slate-900 dark:text-slate-100">{{ formatReturnNumber(purchaseReturn) }}</span>
@@ -173,7 +175,7 @@ const itemColumns: ResponsiveColumn[] = [
           <!-- Action Buttons -->
           <div class="flex flex-wrap gap-2">
             <!-- Edit (draft only) -->
-            <RouterLink v-if="canEdit" :to="`/purchasing/purchase-returns/${returnId}/edit`">
+            <RouterLink v-if="canEdit" :to="copy.editPath(returnId)">
               <Button variant="secondary" size="sm">
                 <Edit class="w-4 h-4 mr-1" />
                 Edit

--- a/src/pages/purchasing/purchase-returns/PurchaseReturnFormPage.vue
+++ b/src/pages/purchasing/purchase-returns/PurchaseReturnFormPage.vue
@@ -13,6 +13,7 @@ import { useContactsLookup } from '@/api/useContacts'
 import { useWarehousesLookup } from '@/api/useWarehouses'
 import { purchaseReturnSchema, type PurchaseReturnFormData, type PurchaseReturnItemFormData } from '@/utils/validation'
 import { setServerErrors } from '@/composables/useValidatedForm'
+import { vendorRefundJourney } from '@/pages/accounting/creditDocuments'
 import { formatCurrency, toNumber } from '@/utils/format'
 import {
   Button,
@@ -37,7 +38,8 @@ const purchaseReturnId = computed(() => {
 })
 
 const isEditing = computed(() => purchaseReturnId.value !== null)
-const pageTitle = computed(() => isEditing.value ? 'Edit Purchase Return' : 'New Purchase Return')
+const copy = computed(() => vendorRefundJourney(route.path))
+const pageTitle = computed(() => isEditing.value ? copy.value.editTitle : copy.value.newTitle)
 
 // Fetch existing purchase return if editing
 const prIdRef = computed(() => purchaseReturnId.value ?? 0)
@@ -186,12 +188,12 @@ const onSubmit = handleSubmit(async (formValues) => {
   try {
     if (isEditing.value && purchaseReturnId.value) {
       await updateMutation.mutateAsync({ id: purchaseReturnId.value, data: payload as any })
-      toast.success('Purchase return updated successfully')
-      router.push(`/purchasing/purchase-returns/${purchaseReturnId.value}`)
+      toast.success(`${copy.value.listTitle.slice(0, -1)} updated successfully`)
+      router.push(copy.value.detailPath(purchaseReturnId.value))
     } else {
       const result = await createMutation.mutateAsync(payload as any)
-      toast.success('Purchase return created successfully')
-      router.push(`/purchasing/purchase-returns/${result.id}`)
+      toast.success(`${copy.value.listTitle.slice(0, -1)} created successfully`)
+      router.push(copy.value.detailPath(result.id))
     }
   } catch (err: unknown) {
     const response = (err as { response?: { data?: { message?: string; errors?: Record<string, string[]> } } })?.response?.data
@@ -230,7 +232,7 @@ const warehouseOptions = computed(() => {
       <div>
         <h1 class="text-2xl font-semibold text-foreground">{{ pageTitle }}</h1>
         <p class="text-muted-foreground">
-          {{ isEditing ? 'Update purchase return details' : 'Create a new purchase return' }}
+          {{ isEditing ? copy.listHint : copy.emptyHint }}
         </p>
       </div>
       <Button variant="ghost" @click="router.back()">
@@ -420,7 +422,7 @@ const warehouseOptions = computed(() => {
           Cancel
         </Button>
         <Button type="submit" :loading="isSubmitting">
-          {{ isEditing ? 'Update Purchase Return' : 'Create Purchase Return' }}
+          {{ isEditing ? copy.saveUpdate : copy.saveCreate }}
         </Button>
       </div>
     </form>

--- a/src/pages/purchasing/purchase-returns/PurchaseReturnListPage.vue
+++ b/src/pages/purchasing/purchase-returns/PurchaseReturnListPage.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
-import { useRouter } from 'vue-router'
+import { computed } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { vendorRefundJourney } from '@/pages/accounting/creditDocuments'
 import {
   usePurchaseReturns,
   getPurchaseReturnStatus,
@@ -17,7 +19,9 @@ import { Button, Input, Select, Badge, Card, Pagination, ResponsiveTable, type R
 import FilterBar from '@/components/ui/FilterBar.vue'
 import FilterGroup from '@/components/ui/FilterGroup.vue'
 
+const route = useRoute()
 const router = useRouter()
+const copy = computed(() => vendorRefundJourney(route.path))
 
 // Resource list with filters and pagination
 const {
@@ -68,7 +72,7 @@ const columns: ResponsiveColumn[] = [
 
 // Navigate to detail
 function viewReturn(item: Record<string, unknown>) {
-  router.push(`/purchasing/purchase-returns/${item.id}`)
+  router.push(copy.value.detailPath(item.id as number))
 }
 </script>
 
@@ -77,13 +81,13 @@ function viewReturn(item: Record<string, unknown>) {
     <!-- Page Header -->
     <div class="flex items-center justify-between mb-6">
       <div>
-        <h1 class="text-2xl font-semibold text-slate-900 dark:text-slate-100">Purchase Returns</h1>
-        <p class="text-slate-500 dark:text-slate-400">Manage returns to vendors</p>
+        <h1 class="text-2xl font-semibold text-slate-900 dark:text-slate-100" data-testid="vendor-refund-heading">{{ copy.listTitle }}</h1>
+        <p class="text-slate-500 dark:text-slate-400">{{ copy.listHint }}</p>
       </div>
-      <RouterLink to="/purchasing/purchase-returns/new">
-        <Button>
+      <RouterLink :to="copy.newPath">
+        <Button data-testid="vendor-refund-new">
           <Plus class="w-4 h-4 mr-2" />
-          New Return
+          {{ copy.createCta }}
         </Button>
       </RouterLink>
     </div>
@@ -127,11 +131,11 @@ function viewReturn(item: Record<string, unknown>) {
     <!-- Empty State -->
     <Card v-else-if="isEmpty" class="text-center py-12">
       <RotateCcw class="w-12 h-12 mx-auto text-slate-300 dark:text-slate-600 mb-3" />
-      <h3 class="text-lg font-medium text-slate-900 dark:text-slate-100 mb-1">No purchase returns found</h3>
+      <h3 class="text-lg font-medium text-slate-900 dark:text-slate-100 mb-1">{{ copy.emptyTitle }}</h3>
       <p class="text-slate-500 dark:text-slate-400 mb-4">
-        Create a return when you need to send goods back to a vendor
+        {{ copy.emptyHint }}
       </p>
-      <RouterLink to="/purchasing/purchase-returns/new">
+      <RouterLink :to="copy.newPath">
         <Button>
           <Plus class="w-4 h-4 mr-2" />
           Create Return

--- a/src/pages/sales/sales-returns/SalesReturnDetailPage.vue
+++ b/src/pages/sales/sales-returns/SalesReturnDetailPage.vue
@@ -13,6 +13,7 @@ import {
   formatReturnNumber,
 } from '@/api/useSalesReturns'
 import { formatCurrency, formatDate, formatDateTime } from '@/utils/format'
+import { customerCreditNoteJourney } from '@/pages/accounting/creditDocuments'
 import {
   ArrowLeft,
   Send,
@@ -42,6 +43,7 @@ import { Button, Badge, Card, Modal, Input, Alert } from '@/components/ui'
 const route = useRoute()
 const router = useRouter()
 const id = computed(() => Number(route.params.id))
+const copy = computed(() => customerCreditNoteJourney(route.path))
 
 // Fetch sales return
 const { data: salesReturn, isLoading, error } = useSalesReturn(id)
@@ -99,11 +101,11 @@ async function handleCancel() {
 
 async function handleDelete() {
   await deleteMutation.mutateAsync(id.value)
-  router.push('/sales/sales-returns')
+  router.push(copy.value.listPath)
 }
 
 function goBack() {
-  router.push('/sales/sales-returns')
+  router.push(copy.value.listPath)
 }
 </script>
 
@@ -188,7 +190,7 @@ function goBack() {
               <DropdownMenuItem
                 v-if="canEdit"
                 class="flex items-center gap-2 px-3 py-2 text-sm text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800 rounded cursor-pointer"
-                @click="router.push(`/sales/sales-returns/${id}/edit`)"
+                @click="router.push(copy.editPath(id))"
               >
                 <Edit class="w-4 h-4" />
                 Edit

--- a/src/pages/sales/sales-returns/SalesReturnFormPage.vue
+++ b/src/pages/sales/sales-returns/SalesReturnFormPage.vue
@@ -13,6 +13,7 @@ import { useContactsLookup } from '@/api/useContacts'
 import { useWarehousesLookup } from '@/api/useInventory'
 import { salesReturnSchema, type SalesReturnFormData, type SalesReturnItemFormData } from '@/utils/validation'
 import { setServerErrors } from '@/composables/useValidatedForm'
+import { customerCreditNoteJourney } from '@/pages/accounting/creditDocuments'
 import { formatCurrency, toNumber } from '@/utils/format'
 import {
   Button,
@@ -37,7 +38,8 @@ const salesReturnId = computed(() => {
 })
 
 const isEditing = computed(() => salesReturnId.value !== null)
-const pageTitle = computed(() => isEditing.value ? 'Edit Sales Return' : 'New Sales Return')
+const copy = computed(() => customerCreditNoteJourney(route.path))
+const pageTitle = computed(() => isEditing.value ? copy.value.editTitle : copy.value.newTitle)
 
 // Fetch existing sales return if editing
 const srIdRef = computed(() => salesReturnId.value ?? 0)
@@ -179,12 +181,12 @@ const onSubmit = handleSubmit(async (formValues) => {
   try {
     if (isEditing.value && salesReturnId.value) {
       await updateMutation.mutateAsync({ id: salesReturnId.value, data: payload as any })
-      toast.success('Sales return updated successfully')
-      router.push(`/sales/sales-returns/${salesReturnId.value}`)
+      toast.success(`${copy.value.listTitle.slice(0, -1)} updated successfully`)
+      router.push(copy.value.detailPath(salesReturnId.value))
     } else {
       const result = await createMutation.mutateAsync(payload as any)
-      toast.success('Sales return created successfully')
-      router.push(`/sales/sales-returns/${result.id}`)
+      toast.success(`${copy.value.listTitle.slice(0, -1)} created successfully`)
+      router.push(copy.value.detailPath(result.id))
     }
   } catch (err: unknown) {
     const response = (err as { response?: { data?: { message?: string; errors?: Record<string, string[]> } } })?.response?.data
@@ -223,7 +225,7 @@ const warehouseOptions = computed(() => {
       <div>
         <h1 class="text-2xl font-semibold text-slate-900 dark:text-slate-100">{{ pageTitle }}</h1>
         <p class="text-slate-500 dark:text-slate-400">
-          {{ isEditing ? 'Update sales return details' : 'Create a new sales return' }}
+          {{ isEditing ? copy.listHint : copy.emptyHint }}
         </p>
       </div>
       <Button variant="ghost" @click="router.back()">
@@ -417,7 +419,7 @@ const warehouseOptions = computed(() => {
           Cancel
         </Button>
         <Button type="submit" :loading="isSubmitting" data-testid="sr-submit">
-          {{ isEditing ? 'Update Sales Return' : 'Create Sales Return' }}
+          {{ isEditing ? copy.saveUpdate : copy.saveCreate }}
         </Button>
       </div>
     </form>

--- a/src/pages/sales/sales-returns/SalesReturnListPage.vue
+++ b/src/pages/sales/sales-returns/SalesReturnListPage.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
-import { useRouter } from 'vue-router'
+import { computed } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { customerCreditNoteJourney } from '@/pages/accounting/creditDocuments'
 import {
   useSalesReturns,
   getSalesReturnStatus,
@@ -17,7 +19,9 @@ import { Button, Input, Select, Badge, Card, Pagination, ResponsiveTable, type R
 import FilterBar from '@/components/ui/FilterBar.vue'
 import FilterGroup from '@/components/ui/FilterGroup.vue'
 
+const route = useRoute()
 const router = useRouter()
+const copy = computed(() => customerCreditNoteJourney(route.path))
 
 // Resource list with filters and pagination
 const {
@@ -68,7 +72,7 @@ const columns: ResponsiveColumn[] = [
 
 // Navigate to detail
 function viewReturn(item: Record<string, unknown>) {
-  router.push(`/sales/sales-returns/${item.id}`)
+  router.push(copy.value.detailPath(item.id as number))
 }
 </script>
 
@@ -77,13 +81,13 @@ function viewReturn(item: Record<string, unknown>) {
     <!-- Page Header -->
     <div class="flex items-center justify-between mb-6">
       <div>
-        <h1 class="text-2xl font-semibold text-slate-900 dark:text-slate-100">Sales Returns</h1>
-        <p class="text-slate-500 dark:text-slate-400">Manage returns from customers</p>
+        <h1 class="text-2xl font-semibold text-slate-900 dark:text-slate-100" data-testid="credit-document-heading">{{ copy.listTitle }}</h1>
+        <p class="text-slate-500 dark:text-slate-400">{{ copy.listHint }}</p>
       </div>
-      <RouterLink to="/sales/sales-returns/new">
-        <Button>
+      <RouterLink :to="copy.newPath">
+        <Button data-testid="credit-document-new">
           <Plus class="w-4 h-4 mr-2" />
-          New Return
+          {{ copy.createCta }}
         </Button>
       </RouterLink>
     </div>
@@ -127,11 +131,11 @@ function viewReturn(item: Record<string, unknown>) {
     <!-- Empty State -->
     <Card v-else-if="isEmpty" class="text-center py-12">
       <RotateCcw class="w-12 h-12 mx-auto text-slate-300 dark:text-slate-600 mb-3" />
-      <h3 class="text-lg font-medium text-slate-900 dark:text-slate-100 mb-1">No sales returns found</h3>
+      <h3 class="text-lg font-medium text-slate-900 dark:text-slate-100 mb-1">{{ copy.emptyTitle }}</h3>
       <p class="text-slate-500 dark:text-slate-400 mb-4">
-        Create a return when a customer returns goods
+        {{ copy.emptyHint }}
       </p>
-      <RouterLink to="/sales/sales-returns/new">
+      <RouterLink :to="copy.newPath">
         <Button>
           <Plus class="w-4 h-4 mr-2" />
           Create Return

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -48,8 +48,12 @@ const FEATURE_ROUTE_PREFIXES: Array<{ prefix: string; feature: string }> = [
   { prefix: '/purchases', feature: 'purchase_orders' },
   { prefix: '/purchasing/goods-receipt-notes', feature: 'goods_receipt_notes' },
   { prefix: '/purchasing/purchase-returns', feature: 'purchase_returns' },
+  { prefix: '/accounting/vendor-refunds', feature: 'purchase_returns' },
+  { prefix: '/vendor-refunds', feature: 'purchase_returns' },
   { prefix: '/sales/delivery-orders', feature: 'delivery_orders' },
   { prefix: '/sales/sales-returns', feature: 'sales_returns' },
+  { prefix: '/accounting/credit-notes', feature: 'sales_returns' },
+  { prefix: '/credit-notes', feature: 'sales_returns' },
   { prefix: '/sales/follow-up', feature: 'quotations' },
   { prefix: '/finance/reminders', feature: 'invoices' },
   { prefix: '/sales/overdue-dashboard', feature: 'invoices' },
@@ -620,6 +624,70 @@ const router = createRouter({
           name: 'journal-entry-detail',
           component: () => import('@/pages/accounting/journal-entries/JournalEntryDetailPage.vue'),
           meta: { breadcrumb: (route) => `Entry #${route.params.id}` }
+        },
+        {
+          path: 'accounting/credit-notes',
+          name: 'credit-notes',
+          component: () => import('@/pages/sales/sales-returns/SalesReturnListPage.vue'),
+          meta: { breadcrumb: 'Credit Notes', feature: 'sales_returns' },
+        },
+        {
+          path: 'accounting/credit-notes/new',
+          name: 'credit-note-new',
+          component: () => import('@/pages/sales/sales-returns/SalesReturnFormPage.vue'),
+          meta: { breadcrumb: 'New Credit Note', feature: 'sales_returns' },
+        },
+        {
+          path: 'accounting/credit-notes/:id',
+          name: 'credit-note-detail',
+          component: () => import('@/pages/sales/sales-returns/SalesReturnDetailPage.vue'),
+          meta: { breadcrumb: (route) => `Credit Note #${route.params.id}`, feature: 'sales_returns' },
+        },
+        {
+          path: 'accounting/credit-notes/:id/edit',
+          name: 'credit-note-edit',
+          component: () => import('@/pages/sales/sales-returns/SalesReturnFormPage.vue'),
+          meta: { breadcrumb: 'Edit Credit Note', feature: 'sales_returns' },
+        },
+        {
+          path: 'credit-notes',
+          redirect: { name: 'credit-notes' },
+        },
+        {
+          path: 'accounting/customer-credit-notes',
+          redirect: { name: 'credit-notes' },
+        },
+        {
+          path: 'accounting/vendor-refunds',
+          name: 'vendor-refunds',
+          component: () => import('@/pages/purchasing/purchase-returns/PurchaseReturnListPage.vue'),
+          meta: { breadcrumb: 'Vendor Refunds', feature: 'purchase_returns' },
+        },
+        {
+          path: 'accounting/vendor-refunds/new',
+          name: 'vendor-refund-new',
+          component: () => import('@/pages/purchasing/purchase-returns/PurchaseReturnFormPage.vue'),
+          meta: { breadcrumb: 'New Vendor Refund', feature: 'purchase_returns' },
+        },
+        {
+          path: 'accounting/vendor-refunds/:id',
+          name: 'vendor-refund-detail',
+          component: () => import('@/pages/purchasing/purchase-returns/PurchaseReturnDetailPage.vue'),
+          meta: { breadcrumb: (route) => `Refund #${route.params.id}`, feature: 'purchase_returns' },
+        },
+        {
+          path: 'accounting/vendor-refunds/:id/edit',
+          name: 'vendor-refund-edit',
+          component: () => import('@/pages/purchasing/purchase-returns/PurchaseReturnFormPage.vue'),
+          meta: { breadcrumb: 'Edit Vendor Refund', feature: 'purchase_returns' },
+        },
+        {
+          path: 'vendor-refunds',
+          redirect: { name: 'vendor-refunds' },
+        },
+        {
+          path: 'accounting/refunds',
+          redirect: { name: 'vendor-refunds' },
         },
         // Accounting - Fiscal Periods routes
         {


### PR DESCRIPTION
Closes satriyop/enter365#141

Live Accounting had no Customer Credit Notes or Vendor Refunds leaves; candidate routes 404'd.

## What
- Sidebar Accounting: **Credit Notes** (\`/accounting/credit-notes\`) and **Vendor Refunds** (\`/accounting/vendor-refunds\`)
- List / new / detail / edit reuse the existing sales-return and purchase-return APIs and workflows
- Redirects from \`/credit-notes\`, \`/vendor-refunds\`, \`/accounting/customer-credit-notes\`, \`/accounting/refunds\`
- Invoice **Create Credit Note** opens the credit-note document

Warehouse **Sales Returns** / **Purchase Returns** menus stay as they are.