### PR TITLE
fix(accounting): Vue template parse error on asset detail (#142)

### DIFF
--- a/src/pages/accounting/assets/AssetDetailPage.vue
+++ b/src/pages/accounting/assets/AssetDetailPage.vue
@@ -43,6 +43,10 @@ async function postNext() {
     toast.error('Failed to post depreciation')
   }
 }
+
+function editAsset() {
+  router.push('/accounting/assets/' + assetId.value + '/edit')
+}
 </script>
 
 <template>
@@ -63,7 +67,7 @@ async function postNext() {
           <p class="text-slate-500">{{ asset.status }} · book {{ formatCurrency(asset.book_value) }}</p>
         </div>
         <div class="flex gap-2">
-          <Button v-if="asset.status === 'draft'" variant="secondary" @click="router.push(`/accounting/assets/${asset.id}/edit')">
+          <Button v-if="asset.status === 'draft'" variant="secondary" @click="editAsset">
             Edit
           </Button>
           <Button v-if="asset.status === 'draft'" data-testid="asset-confirm" @click="confirm">

--- a/src/pages/accounting/assets/__tests__/fixedAssets.test.ts
+++ b/src/pages/accounting/assets/__tests__/fixedAssets.test.ts
@@ -29,5 +29,9 @@ describe('fixed assets (#142)', () => {
     expect(api).toContain('useConfirmFixedAsset')
     expect(api).toContain('usePostAssetDepreciation')
     expect(api).toContain('/depreciation-schedule')
+
+    const detail = readFileSync(resolve(__dirname, '../AssetDetailPage.vue'), 'utf8')
+    expect(detail).not.toContain('router.push(`')
+    expect(detail).toContain('editAsset')
   })
 })

--- a/src/pages/accounting/depreciation-schedule/DepreciationSchedulePage.vue
+++ b/src/pages/accounting/depreciation-schedule/DepreciationSchedulePage.vue
@@ -13,6 +13,10 @@ const filters = ref<DepreciationScheduleFilters>({
 })
 const { data, isLoading, error } = useDepreciationSchedule(filters)
 
+function openLine(row: { fixed_asset_id: number }) {
+  router.push('/accounting/assets/' + row.fixed_asset_id)
+}
+
 const columns: ResponsiveColumn[] = [
   { key: 'depreciation_date', label: 'Date', mobilePriority: 1 },
   { key: 'asset', label: 'Asset', mobilePriority: 2 },
@@ -56,7 +60,7 @@ const columns: ResponsiveColumn[] = [
         :columns="columns"
         :loading="isLoading"
         row-key="id"
-        @row-click="(row) => router.push(`/accounting/assets/${row.fixed_asset_id}`)"
+        @row-click="openLine"
       >
         <template #cell-depreciation_date="{ item }">{{ formatDate(item.depreciation_date) }}</template>
         <template #cell-asset="{ item }">{{ item.asset ? `${item.asset.code} · ${item.asset.name}` : item.fixed_asset_id }}</template>


### PR DESCRIPTION
## Summary
Deploy of #142 failed: nested backticks in `AssetDetailPage.vue` broke the Vite Vue parser. Move navigation into methods.

Vite build now succeeds.

## Test plan
- [x] vitest fixedAssets
- [x] `npx vite build`