### PR TITLE
feat(accounting): add Loans and Loans Analysis pages (#143)

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -3848,6 +3848,90 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/loans": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List the loan register (Odoo Accounting › Loans) */
+        get: operations["loans.index"];
+        put?: never;
+        post: operations["loans.store"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/loans/{loan}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["loans.show"];
+        put: operations["loans.update"];
+        post?: never;
+        delete: operations["loans.destroy"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/loans/{loan}/confirm": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Confirm a draft loan: generate the amortization board and post disbursement */
+        post: operations["loan.confirm"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/loans/{loan}/post-installment": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Post the next installment (principal + interest) to the journal */
+        post: operations["loan.postInstallment"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/loans-analysis": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Loans analysis (Odoo Review › Loans Analysis) */
+        get: operations["loanAnalysis.show"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/reports/work-order-costs": {
         parameters: {
             query?: never;
@@ -9615,6 +9699,47 @@ export interface components {
             value: string;
             label: string;
         };
+        /** LoanLineResource */
+        LoanLineResource: {
+            id: string;
+            loan_id: string;
+            sequence: string;
+            due_date: string | null;
+            principal_amount: string;
+            interest_amount: string;
+            payment_amount: string;
+            remaining_principal: string;
+            status: string;
+            journal_entry_id: string;
+            posted_at: string | null;
+        };
+        /** LoanResource */
+        LoanResource: {
+            id: string;
+            code: string;
+            name: string;
+            contact_id: string;
+            principal: string;
+            annual_interest_rate: number;
+            duration_months: string;
+            start_date: string | null;
+            liability_account_id: string;
+            interest_account_id: string;
+            bank_account_id: string;
+            journal_id: string;
+            status: string;
+            remaining_principal: string;
+            disbursement_journal_entry_id: string;
+            notes: string;
+            contact?: {
+                id: number;
+                code: string;
+                name: string;
+            } | null;
+            lines?: components["schemas"]["LoanLineResource"][];
+            created_at: string | null;
+            updated_at: string | null;
+        };
         /** LoginRequest */
         LoginRequest: {
             /** Format: email */
@@ -11811,6 +11936,22 @@ export interface components {
             currency?: "IDR" | "USD" | "EUR" | "SGD" | "JPY" | "CNY" | null;
             is_active?: boolean;
         };
+        /** StoreLoanRequest */
+        StoreLoanRequest: {
+            code: string;
+            name: string;
+            contact_id?: number | null;
+            principal: number;
+            annual_interest_rate?: number | null;
+            duration_months: number;
+            /** Format: date-time */
+            start_date: string;
+            liability_account_id: number;
+            interest_account_id: number;
+            bank_account_id: number;
+            journal_id?: number | null;
+            notes?: string | null;
+        };
         /** StoreMaterialRequisitionRequest */
         StoreMaterialRequisitionRequest: {
             warehouse_id?: number | null;
@@ -13019,6 +13160,22 @@ export interface components {
             /** @enum {string|null} */
             currency?: "IDR" | "USD" | "EUR" | "SGD" | "JPY" | "CNY" | null;
             is_active?: boolean;
+        };
+        /** UpdateLoanRequest */
+        UpdateLoanRequest: {
+            code?: string;
+            name?: string;
+            contact_id?: number | null;
+            principal?: number;
+            annual_interest_rate?: number | null;
+            duration_months?: number;
+            /** Format: date-time */
+            start_date?: string;
+            liability_account_id?: number;
+            interest_account_id?: number;
+            bank_account_id?: number;
+            journal_id?: number | null;
+            notes?: string | null;
         };
         /** UpdateMaterialRequisitionRequest */
         UpdateMaterialRequisitionRequest: {
@@ -24585,6 +24742,260 @@ export interface operations {
                     };
                 };
             };
+        };
+    };
+    "loans.index": {
+        parameters: {
+            query?: {
+                per_page?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Paginated set of `LoanResource` */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data: (components["schemas"]["LoanResource"] & Record<string, never>)[];
+                        links: {
+                            first: string | null;
+                            last: string | null;
+                            prev: string | null;
+                            next: string | null;
+                        };
+                        meta: {
+                            current_page: number;
+                            from: number | null;
+                            last_page: number;
+                            /** @description Generated paginator links. */
+                            links: {
+                                url: string | null;
+                                label: string;
+                                active: boolean;
+                            }[];
+                            /** @description Base path for paginator generated URLs. */
+                            path: string | null;
+                            /** @description Number of items shown per page. */
+                            per_page: number;
+                            /** @description Number of the last item in the slice. */
+                            to: number | null;
+                            /** @description Total number of items being paginated. */
+                            total: number;
+                        };
+                    };
+                };
+            };
+            401: components["responses"]["AuthenticationException"];
+            403: components["responses"]["AuthorizationException"];
+        };
+    };
+    "loans.store": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["StoreLoanRequest"];
+            };
+        };
+        responses: {
+            /** @description `LoanResource` */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data: components["schemas"]["LoanResource"] & Record<string, never>;
+                    };
+                };
+            };
+            401: components["responses"]["AuthenticationException"];
+            403: components["responses"]["AuthorizationException"];
+            422: components["responses"]["ValidationException"];
+        };
+    };
+    "loans.show": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The loan ID */
+                loan: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description `LoanResource` */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data: components["schemas"]["LoanResource"] & Record<string, never>;
+                    };
+                };
+            };
+            401: components["responses"]["AuthenticationException"];
+            403: components["responses"]["AuthorizationException"];
+            404: components["responses"]["ModelNotFoundException"];
+        };
+    };
+    "loans.update": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The loan ID */
+                loan: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["UpdateLoanRequest"];
+            };
+        };
+        responses: {
+            /** @description `LoanResource` */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data: components["schemas"]["LoanResource"];
+                    };
+                };
+            };
+            401: components["responses"]["AuthenticationException"];
+            403: components["responses"]["AuthorizationException"];
+            404: components["responses"]["ModelNotFoundException"];
+            422: components["responses"]["ValidationException"];
+        };
+    };
+    "loans.destroy": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The loan ID */
+                loan: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        success: boolean;
+                        /** @constant */
+                        message: "Pinjaman berhasil dihapus.";
+                    };
+                };
+            };
+            401: components["responses"]["AuthenticationException"];
+            403: components["responses"]["AuthorizationException"];
+            404: components["responses"]["ModelNotFoundException"];
+        };
+    };
+    "loan.confirm": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The loan ID */
+                loan: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description `LoanResource` */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data: components["schemas"]["LoanResource"];
+                    };
+                };
+            };
+            401: components["responses"]["AuthenticationException"];
+            403: components["responses"]["AuthorizationException"];
+            404: components["responses"]["ModelNotFoundException"];
+        };
+    };
+    "loan.postInstallment": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The loan ID */
+                loan: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description `LoanResource` */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data: components["schemas"]["LoanResource"];
+                    };
+                };
+            };
+            401: components["responses"]["AuthenticationException"];
+            403: components["responses"]["AuthorizationException"];
+            404: components["responses"]["ModelNotFoundException"];
+        };
+    };
+    "loanAnalysis.show": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        success: boolean;
+                        /** @constant */
+                        message: "Operasi berhasil.";
+                        data: {
+                            [key: string]: unknown;
+                        };
+                    };
+                };
+            };
+            401: components["responses"]["AuthenticationException"];
+            403: components["responses"]["AuthorizationException"];
         };
     };
     "reports.work-order-costs": {

--- a/src/api/useLoans.ts
+++ b/src/api/useLoans.ts
@@ -1,0 +1,146 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/vue-query'
+import { createCrudHooks } from './factory'
+import { api } from './client'
+
+export type LoanStatus = 'draft' | 'running' | 'closed'
+export type LoanLineStatus = 'draft' | 'posted'
+
+export interface LoanLine {
+  id: number
+  loan_id: number
+  sequence: number
+  due_date: string
+  principal_amount: number
+  interest_amount: number
+  payment_amount: number
+  remaining_principal: number
+  status: LoanLineStatus
+  journal_entry_id?: number | null
+  posted_at?: string | null
+}
+
+export interface Loan {
+  id: number
+  code: string
+  name: string
+  contact_id?: number | null
+  principal: number
+  annual_interest_rate: number
+  duration_months: number
+  start_date: string
+  liability_account_id: number
+  interest_account_id: number
+  bank_account_id: number
+  journal_id?: number | null
+  status: LoanStatus
+  remaining_principal: number
+  disbursement_journal_entry_id?: number | null
+  notes?: string | null
+  contact?: { id: number; code: string; name: string } | null
+  lines?: LoanLine[]
+}
+
+export interface LoanFilters {
+  page?: number
+  per_page?: number
+  search?: string
+  status?: string
+}
+
+export interface CreateLoanData {
+  code: string
+  name: string
+  contact_id?: number | null
+  principal: number
+  annual_interest_rate?: number
+  duration_months: number
+  start_date: string
+  liability_account_id: number
+  interest_account_id: number
+  bank_account_id: number
+  journal_id?: number | null
+  notes?: string | null
+}
+
+export type UpdateLoanData = Partial<CreateLoanData>
+
+export interface LoanAnalysisRow {
+  status: LoanStatus
+  loan_count: number
+  total_principal: number
+  remaining_principal: number
+}
+
+export interface LoanAnalysisUpcoming {
+  id: number
+  loan_id: number
+  loan_code: string
+  loan_name: string
+  sequence: number
+  due_date: string
+  principal_amount: number
+  interest_amount: number
+  payment_amount: number
+  remaining_principal: number
+  status: LoanLineStatus
+}
+
+export interface LoanAnalysis {
+  loan_count: number
+  running_count: number
+  total_principal: number
+  remaining_principal: number
+  interest_posted: number
+  interest_remaining: number
+  by_status: LoanAnalysisRow[]
+  upcoming: LoanAnalysisUpcoming[]
+}
+
+const hooks = createCrudHooks<Loan, LoanFilters, CreateLoanData, UpdateLoanData>({
+  resourceName: 'loans',
+  singularName: 'loan',
+})
+
+export const useLoans = hooks.useList
+export const useLoan = hooks.useSingle
+export const useCreateLoan = hooks.useCreate
+export const useUpdateLoan = hooks.useUpdate
+export const useDeleteLoan = hooks.useDelete
+
+export function useConfirmLoan() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async (id: number | string) => {
+      const response = await api.post<{ data: Loan }>(`/loans/${id}/confirm`)
+      return response.data.data
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['loans'] })
+      queryClient.invalidateQueries({ queryKey: ['loans-analysis'] })
+    },
+  })
+}
+
+export function usePostLoanInstallment() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async (id: number | string) => {
+      const response = await api.post<{ data: Loan }>(`/loans/${id}/post-installment`)
+      return response.data.data
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['loans'] })
+      queryClient.invalidateQueries({ queryKey: ['loans-analysis'] })
+    },
+  })
+}
+
+export function useLoansAnalysis() {
+  return useQuery({
+    queryKey: ['loans-analysis'],
+    queryFn: async () => {
+      const response = await api.get<{ data: LoanAnalysis }>('/loans-analysis')
+      return response.data.data
+    },
+  })
+}

--- a/src/config/nav.ts
+++ b/src/config/nav.ts
@@ -89,6 +89,8 @@ export const navigation: NavGroup[] = [
       { name: 'Assets', path: '/accounting/assets', icon: '🏢', permission: 'journals.view' },
       { name: 'Asset Models', path: '/accounting/asset-models', icon: '📐', permission: 'journals.view' },
       { name: 'Depreciation Schedule', path: '/accounting/depreciation-schedule', icon: '📉', permission: 'journals.view' },
+      { name: 'Loans', path: '/accounting/loans', icon: '🏦', permission: 'journals.view' },
+      { name: 'Loans Analysis', path: '/accounting/loans-analysis', icon: '📈', permission: 'journals.view' },
       { name: 'Journal Entries', path: '/accounting/journal-entries', icon: '📝', permission: 'journals.view' },
       { name: 'Fiscal Periods', path: '/accounting/fiscal-periods', icon: '📅', permission: 'fiscal_periods.view' },
       { name: 'Budgets', path: '/accounting/budgets', icon: '📊', permission: 'budgets.view', feature: 'budgeting' },

--- a/src/layouts/AppSidebar.vue
+++ b/src/layouts/AppSidebar.vue
@@ -132,7 +132,11 @@ onBeforeUnmount(stopNavRescue)
                   ? 'sidebar-fiscal-positions'
                   : item.path === '/accounting/assets'
                     ? 'sidebar-assets'
-                    : undefined"
+                    : item.path === '/accounting/loans'
+                      ? 'sidebar-loans'
+                      : item.path === '/accounting/loans-analysis'
+                        ? 'sidebar-loans-analysis'
+                        : undefined"
           data-rescue="nav"
           class="flex items-center gap-3 px-4 py-2.5 mx-2 rounded-lg text-sm font-medium transition-colors"
           :class="[

--- a/src/pages/accounting/loans-analysis/LoansAnalysisPage.vue
+++ b/src/pages/accounting/loans-analysis/LoansAnalysisPage.vue
@@ -1,0 +1,99 @@
+<script setup lang="ts">
+import { useRouter } from 'vue-router'
+import { useLoansAnalysis, type LoanAnalysisUpcoming } from '@/api/useLoans'
+import { formatCurrency, formatDate } from '@/utils/format'
+import { Card, ResponsiveTable, type ResponsiveColumn } from '@/components/ui'
+
+const router = useRouter()
+const { data, isLoading, error } = useLoansAnalysis()
+
+function openLoan(row: LoanAnalysisUpcoming) {
+  router.push('/accounting/loans/' + row.loan_id)
+}
+
+const statusColumns: ResponsiveColumn[] = [
+  { key: 'status', label: 'Status', mobilePriority: 1 },
+  { key: 'loan_count', label: 'Loans', mobilePriority: 2 },
+  { key: 'total_principal', label: 'Principal', mobilePriority: 3 },
+  { key: 'remaining_principal', label: 'Remaining', mobilePriority: 4 },
+]
+
+const upcomingColumns: ResponsiveColumn[] = [
+  { key: 'due_date', label: 'Due', mobilePriority: 1 },
+  { key: 'loan_code', label: 'Loan', mobilePriority: 2 },
+  { key: 'payment_amount', label: 'Payment', mobilePriority: 3 },
+  { key: 'principal_amount', label: 'Principal', showInMobile: false },
+  { key: 'interest_amount', label: 'Interest', showInMobile: false },
+  { key: 'status', label: 'Status', mobilePriority: 4 },
+]
+</script>
+
+<template>
+  <div>
+    <div class="mb-6">
+      <h1 class="text-2xl font-semibold text-slate-900 dark:text-slate-100">Loans Analysis</h1>
+      <p class="text-slate-500 dark:text-slate-400">
+        Review remaining principal, posted interest, and upcoming installments.
+      </p>
+    </div>
+
+    <div v-if="error" class="text-red-500">Failed to load loans analysis</div>
+    <div v-else-if="isLoading || !data" class="text-slate-500">Loading…</div>
+    <template v-else>
+      <div class="grid grid-cols-1 md:grid-cols-4 gap-4 mb-6">
+        <Card class="p-4">
+          <div class="text-sm text-slate-500">Loans</div>
+          <div class="font-semibold">{{ data.loan_count }} ({{ data.running_count }} running)</div>
+        </Card>
+        <Card class="p-4">
+          <div class="text-sm text-slate-500">Principal</div>
+          <div class="font-semibold">{{ formatCurrency(data.total_principal) }}</div>
+        </Card>
+        <Card class="p-4">
+          <div class="text-sm text-slate-500">Remaining</div>
+          <div class="font-semibold">{{ formatCurrency(data.remaining_principal) }}</div>
+        </Card>
+        <Card class="p-4">
+          <div class="text-sm text-slate-500">Interest posted</div>
+          <div class="font-semibold">{{ formatCurrency(data.interest_posted) }}</div>
+        </Card>
+      </div>
+
+      <Card class="mb-6">
+        <div class="p-4 font-semibold">By status</div>
+        <div v-if="!data.by_status.length" class="py-8 text-center text-slate-500">
+          No loans yet. Create a loan from the register.
+        </div>
+        <ResponsiveTable
+          v-else
+          :items="data.by_status"
+          :columns="statusColumns"
+          row-key="status"
+        >
+          <template #cell-total_principal="{ item }">{{ formatCurrency(item.total_principal) }}</template>
+          <template #cell-remaining_principal="{ item }">{{ formatCurrency(item.remaining_principal) }}</template>
+        </ResponsiveTable>
+      </Card>
+
+      <Card>
+        <div class="p-4 font-semibold">Upcoming installments</div>
+        <div v-if="!data.upcoming.length" class="py-8 text-center text-slate-500">
+          No draft installments. Confirm a loan to generate its board.
+        </div>
+        <ResponsiveTable
+          v-else
+          :items="data.upcoming"
+          :columns="upcomingColumns"
+          row-key="id"
+          @row-click="openLoan"
+        >
+          <template #cell-due_date="{ item }">{{ formatDate(item.due_date) }}</template>
+          <template #cell-loan_code="{ item }">{{ item.loan_code }} · {{ item.loan_name }}</template>
+          <template #cell-payment_amount="{ item }">{{ formatCurrency(item.payment_amount) }}</template>
+          <template #cell-principal_amount="{ item }">{{ formatCurrency(item.principal_amount) }}</template>
+          <template #cell-interest_amount="{ item }">{{ formatCurrency(item.interest_amount) }}</template>
+        </ResponsiveTable>
+      </Card>
+    </template>
+  </div>
+</template>

--- a/src/pages/accounting/loans/LoanDetailPage.vue
+++ b/src/pages/accounting/loans/LoanDetailPage.vue
@@ -1,0 +1,123 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import {
+  useConfirmLoan,
+  useLoan,
+  usePostLoanInstallment,
+} from '@/api/useLoans'
+import { formatCurrency, formatDate } from '@/utils/format'
+import { Button, Card, ResponsiveTable, useToast, type ResponsiveColumn } from '@/components/ui'
+import { ArrowLeft } from 'lucide-vue-next'
+
+const route = useRoute()
+const router = useRouter()
+const toast = useToast()
+const loanId = computed(() => String(route.params.id ?? ''))
+const { data: loan, isLoading, error } = useLoan(loanId)
+const confirmMutation = useConfirmLoan()
+const postMutation = usePostLoanInstallment()
+
+const columns: ResponsiveColumn[] = [
+  { key: 'sequence', label: '#', mobilePriority: 1 },
+  { key: 'due_date', label: 'Due', mobilePriority: 2 },
+  { key: 'principal_amount', label: 'Principal', mobilePriority: 3 },
+  { key: 'interest_amount', label: 'Interest', showInMobile: false },
+  { key: 'payment_amount', label: 'Payment', mobilePriority: 4 },
+  { key: 'remaining_principal', label: 'Remaining', showInMobile: false },
+  { key: 'status', label: 'Status', showInMobile: false },
+]
+
+async function confirm() {
+  try {
+    await confirmMutation.mutateAsync(loanId.value)
+    toast.success('Loan confirmed and schedule generated')
+  } catch {
+    toast.error('Failed to confirm loan')
+  }
+}
+
+async function postNext() {
+  try {
+    await postMutation.mutateAsync(loanId.value)
+    toast.success('Installment posted')
+  } catch {
+    toast.error('Failed to post installment')
+  }
+}
+
+function editLoan() {
+  router.push('/accounting/loans/' + loanId.value + '/edit')
+}
+
+function goList() {
+  router.push('/accounting/loans')
+}
+</script>
+
+<template>
+  <div>
+    <div class="flex items-center gap-2 text-sm text-slate-500 mb-4">
+      <button type="button" class="hover:text-slate-700 flex items-center gap-1" @click="goList">
+        <ArrowLeft class="w-4 h-4" />
+        Loans
+      </button>
+    </div>
+
+    <div v-if="error" class="text-red-500">Failed to load loan</div>
+    <div v-else-if="isLoading || !loan" class="text-slate-500">Loading…</div>
+    <template v-else>
+      <div class="flex items-center justify-between mb-6">
+        <div>
+          <h1 class="text-2xl font-semibold">{{ loan.code }} · {{ loan.name }}</h1>
+          <p class="text-slate-500">{{ loan.status }} · remaining {{ formatCurrency(loan.remaining_principal) }}</p>
+        </div>
+        <div class="flex gap-2">
+          <Button v-if="loan.status === 'draft'" variant="secondary" @click="editLoan">
+            Edit
+          </Button>
+          <Button v-if="loan.status === 'draft'" data-testid="loan-confirm" @click="confirm">
+            Confirm
+          </Button>
+          <Button v-if="loan.status === 'running'" data-testid="loan-post-installment" @click="postNext">
+            Post next installment
+          </Button>
+        </div>
+      </div>
+
+      <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
+        <Card class="p-4">
+          <div class="text-sm text-slate-500">Principal</div>
+          <div class="font-semibold">{{ formatCurrency(loan.principal) }}</div>
+        </Card>
+        <Card class="p-4">
+          <div class="text-sm text-slate-500">Interest rate</div>
+          <div class="font-semibold">{{ loan.annual_interest_rate }}% / {{ loan.duration_months }} mo</div>
+        </Card>
+        <Card class="p-4">
+          <div class="text-sm text-slate-500">Start</div>
+          <div class="font-semibold">{{ formatDate(loan.start_date) }}</div>
+        </Card>
+      </div>
+
+      <Card>
+        <div class="p-4 font-semibold">Amortization schedule</div>
+        <div v-if="!loan.lines?.length" class="py-8 text-center text-slate-500">
+          Confirm the loan to generate the schedule and post disbursement.
+        </div>
+        <ResponsiveTable
+          v-else
+          :items="loan.lines"
+          :columns="columns"
+          row-key="id"
+        >
+          <template #cell-due_date="{ item }">{{ formatDate(item.due_date) }}</template>
+          <template #cell-principal_amount="{ item }">{{ formatCurrency(item.principal_amount) }}</template>
+          <template #cell-interest_amount="{ item }">{{ formatCurrency(item.interest_amount) }}</template>
+          <template #cell-payment_amount="{ item }">{{ formatCurrency(item.payment_amount) }}</template>
+          <template #cell-remaining_principal="{ item }">{{ formatCurrency(item.remaining_principal) }}</template>
+        </ResponsiveTable>
+      </Card>
+    </template>
+  </div>
+</template>

--- a/src/pages/accounting/loans/LoanFormPage.vue
+++ b/src/pages/accounting/loans/LoanFormPage.vue
@@ -1,0 +1,145 @@
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { useAccountsLookup } from '@/api/useAccounts'
+import { useCreateLoan, useLoan, useUpdateLoan } from '@/api/useLoans'
+import { Button, Card, Input, Select, useToast } from '@/components/ui'
+import { ArrowLeft } from 'lucide-vue-next'
+
+const route = useRoute()
+const router = useRouter()
+const toast = useToast()
+
+const loanId = computed(() => (route.params.id ? String(route.params.id) : ''))
+const isEditing = computed(() => !!loanId.value)
+const { data: existing } = useLoan(loanId)
+const { data: liabilityAccounts } = useAccountsLookup('liability')
+const { data: expenseAccounts } = useAccountsLookup('expense')
+const { data: assetAccounts } = useAccountsLookup('asset')
+
+const code = ref('')
+const name = ref('')
+const principal = ref('')
+const annualInterestRate = ref('0')
+const durationMonths = ref('12')
+const startDate = ref(new Date().toISOString().slice(0, 10))
+const liabilityAccountId = ref('')
+const interestAccountId = ref('')
+const bankAccountId = ref('')
+
+watch(existing, (loan) => {
+  if (!loan) return
+  code.value = loan.code
+  name.value = loan.name
+  principal.value = String(loan.principal)
+  annualInterestRate.value = String(loan.annual_interest_rate)
+  durationMonths.value = String(loan.duration_months)
+  startDate.value = loan.start_date
+  liabilityAccountId.value = String(loan.liability_account_id)
+  interestAccountId.value = String(loan.interest_account_id)
+  bankAccountId.value = String(loan.bank_account_id)
+}, { immediate: true })
+
+function toAccountOptions(accounts: { id: number; code: string; name: string }[] | undefined) {
+  return (accounts ?? []).map((account) => ({
+    value: String(account.id),
+    label: account.code + ' · ' + account.name,
+  }))
+}
+
+const liabilityOptions = computed(() => toAccountOptions(liabilityAccounts.value))
+const interestOptions = computed(() => toAccountOptions(expenseAccounts.value))
+const bankOptions = computed(() => toAccountOptions(assetAccounts.value))
+
+const createMutation = useCreateLoan()
+const updateMutation = useUpdateLoan()
+
+function goBack() {
+  if (isEditing.value) {
+    router.push('/accounting/loans/' + loanId.value)
+    return
+  }
+  router.push('/accounting/loans')
+}
+
+async function handleSubmit() {
+  if (!code.value.trim() || !name.value.trim() || !principal.value) {
+    toast.error('Code, name, and principal are required')
+    return
+  }
+  if (!liabilityAccountId.value || !interestAccountId.value || !bankAccountId.value) {
+    toast.error('Liability, interest, and bank accounts are required')
+    return
+  }
+
+  const payload = {
+    code: code.value.trim(),
+    name: name.value.trim(),
+    principal: Number(principal.value),
+    annual_interest_rate: Number(annualInterestRate.value) || 0,
+    duration_months: Number(durationMonths.value),
+    start_date: startDate.value,
+    liability_account_id: Number(liabilityAccountId.value),
+    interest_account_id: Number(interestAccountId.value),
+    bank_account_id: Number(bankAccountId.value),
+  }
+
+  try {
+    if (isEditing.value) {
+      await updateMutation.mutateAsync({ id: loanId.value, data: payload })
+      toast.success('Loan updated')
+      router.push('/accounting/loans/' + loanId.value)
+    } else {
+      const created = await createMutation.mutateAsync(payload)
+      toast.success('Loan created')
+      router.push('/accounting/loans/' + created.id)
+    }
+  } catch {
+    toast.error('Failed to save loan')
+  }
+}
+</script>
+
+<template>
+  <div>
+    <div class="flex items-center gap-2 text-sm text-slate-500 mb-4">
+      <button type="button" class="hover:text-slate-700 flex items-center gap-1" @click="goBack">
+        <ArrowLeft class="w-4 h-4" />
+        Loans
+      </button>
+    </div>
+    <h1 class="text-2xl font-semibold mb-6">{{ isEditing ? 'Edit Loan' : 'New Loan' }}</h1>
+    <form class="max-w-xl space-y-4" @submit.prevent="handleSubmit">
+      <Card class="space-y-4 p-4">
+        <Input v-model="code" data-testid="loan-code" placeholder="Code" />
+        <Input v-model="name" data-testid="loan-name" placeholder="Name" />
+        <Input v-model="principal" type="number" min="1" data-testid="loan-principal" placeholder="Principal" />
+        <Input v-model="annualInterestRate" type="number" min="0" step="0.01" data-testid="loan-interest-rate" placeholder="Annual interest %" />
+        <Input v-model="durationMonths" type="number" min="1" data-testid="loan-duration" placeholder="Duration (months)" />
+        <Input v-model="startDate" type="date" data-testid="loan-start-date" />
+        <Select
+          :model-value="liabilityAccountId"
+          :options="liabilityOptions"
+          placeholder="Liability account"
+          test-id="loan-liability-account"
+          @update:model-value="(v) => { liabilityAccountId = v ? String(v) : '' }"
+        />
+        <Select
+          :model-value="interestAccountId"
+          :options="interestOptions"
+          placeholder="Interest expense account"
+          test-id="loan-interest-account"
+          @update:model-value="(v) => { interestAccountId = v ? String(v) : '' }"
+        />
+        <Select
+          :model-value="bankAccountId"
+          :options="bankOptions"
+          placeholder="Bank / cash account"
+          test-id="loan-bank-account"
+          @update:model-value="(v) => { bankAccountId = v ? String(v) : '' }"
+        />
+      </Card>
+      <Button type="submit" data-testid="loan-save">Save</Button>
+    </form>
+  </div>
+</template>

--- a/src/pages/accounting/loans/LoanListPage.vue
+++ b/src/pages/accounting/loans/LoanListPage.vue
@@ -1,0 +1,88 @@
+<script setup lang="ts">
+import { useRouter } from 'vue-router'
+import { useLoans, type Loan, type LoanFilters } from '@/api/useLoans'
+import { useResourceList } from '@/composables/useResourceList'
+import { formatCurrency, formatDate } from '@/utils/format'
+import { Button, Card, Input, ResponsiveTable, type ResponsiveColumn } from '@/components/ui'
+import { Plus, Search } from 'lucide-vue-next'
+
+const router = useRouter()
+
+const {
+  items: loans,
+  isLoading,
+  error,
+  isEmpty,
+  filters,
+  updateFilter,
+} = useResourceList<Loan, LoanFilters>({
+  useListHook: useLoans,
+  initialFilters: { page: 1, per_page: 50, search: '' },
+})
+
+const columns: ResponsiveColumn[] = [
+  { key: 'code', label: 'Code', mobilePriority: 1 },
+  { key: 'name', label: 'Name', mobilePriority: 2 },
+  { key: 'principal', label: 'Principal', mobilePriority: 3 },
+  { key: 'remaining_principal', label: 'Remaining', mobilePriority: 4 },
+  { key: 'status', label: 'Status', showInMobile: false },
+  { key: 'start_date', label: 'Start', showInMobile: false },
+]
+
+function openLoan(loan: Loan) {
+  router.push('/accounting/loans/' + loan.id)
+}
+
+function createLoan() {
+  router.push('/accounting/loans/new')
+}
+</script>
+
+<template>
+  <div>
+    <div class="flex items-center justify-between mb-6">
+      <div>
+        <h1 class="text-2xl font-semibold text-slate-900 dark:text-slate-100">Loans</h1>
+        <p class="text-slate-500 dark:text-slate-400">
+          Loan register. Confirm to generate the amortization schedule and post disbursement.
+        </p>
+      </div>
+      <Button data-testid="loan-create" @click="createLoan">
+        <Plus class="w-4 h-4 mr-1" />
+        New Loan
+      </Button>
+    </div>
+
+    <Card class="mb-4">
+      <div class="p-4">
+        <div class="relative">
+          <Search class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400" />
+          <Input
+            :model-value="filters.search ?? ''"
+            class="pl-9"
+            placeholder="Search code or name..."
+            data-testid="loan-search"
+            @update:model-value="(v) => updateFilter('search', String(v))"
+          />
+        </div>
+      </div>
+    </Card>
+
+    <Card>
+      <div v-if="error" class="py-12 text-center text-red-500">Failed to load loans</div>
+      <div v-else-if="isEmpty && !isLoading" class="py-12 text-center text-slate-500">No loans found</div>
+      <ResponsiveTable
+        v-else
+        :items="loans ?? []"
+        :columns="columns"
+        :loading="isLoading"
+        row-key="id"
+        @row-click="openLoan"
+      >
+        <template #cell-principal="{ item }">{{ formatCurrency(item.principal) }}</template>
+        <template #cell-remaining_principal="{ item }">{{ formatCurrency(item.remaining_principal) }}</template>
+        <template #cell-start_date="{ item }">{{ formatDate(item.start_date) }}</template>
+      </ResponsiveTable>
+    </Card>
+  </div>
+</template>

--- a/src/pages/accounting/loans/__tests__/loans.test.ts
+++ b/src/pages/accounting/loans/__tests__/loans.test.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+describe('loans (#143)', () => {
+  it('exposes Loans and Loans Analysis distinct from Assets', () => {
+    const nav = readFileSync(resolve(__dirname, '../../../../config/nav.ts'), 'utf8')
+    const router = readFileSync(resolve(__dirname, '../../../../router/index.ts'), 'utf8')
+    const sidebar = readFileSync(resolve(__dirname, '../../../../layouts/AppSidebar.vue'), 'utf8')
+    const list = readFileSync(resolve(__dirname, '../LoanListPage.vue'), 'utf8')
+    const analysis = readFileSync(resolve(__dirname, '../../loans-analysis/LoansAnalysisPage.vue'), 'utf8')
+    const api = readFileSync(resolve(__dirname, '../../../../api/useLoans.ts'), 'utf8')
+    const detail = readFileSync(resolve(__dirname, '../LoanDetailPage.vue'), 'utf8')
+    const form = readFileSync(resolve(__dirname, '../LoanFormPage.vue'), 'utf8')
+
+    expect(nav).toContain("name: 'Loans'")
+    expect(nav).toContain('/accounting/loans')
+    expect(nav).toContain("name: 'Loans Analysis'")
+    expect(nav).toContain('/accounting/loans-analysis')
+    expect(router).toContain("path: 'accounting/loans'")
+    expect(router).toContain("path: 'accounting/loans-analysis'")
+    expect(router).toContain("path: 'loans'")
+    expect(router).toContain("path: 'loans-analysis'")
+    expect(sidebar).toContain('sidebar-loans')
+    expect(sidebar).toContain('sidebar-loans-analysis')
+    expect(list).toContain('New Loan')
+    expect(analysis).toContain('Loans Analysis')
+    expect(api).toContain('useConfirmLoan')
+    expect(api).toContain('usePostLoanInstallment')
+    expect(api).toContain('/loans-analysis')
+    expect(detail).not.toContain('router.push(`')
+    expect(form).not.toContain('router.push(`')
+    expect(analysis).not.toContain('router.push(`')
+    expect(detail).toContain('editLoan')
+  })
+})

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -704,6 +704,44 @@ const router = createRouter({
           component: () => import('@/pages/accounting/depreciation-schedule/DepreciationSchedulePage.vue'),
           meta: { breadcrumb: 'Depreciation Schedule' }
         },
+        {
+          path: 'accounting/loans',
+          name: 'loans',
+          component: () => import('@/pages/accounting/loans/LoanListPage.vue'),
+          meta: { breadcrumb: 'Loans' }
+        },
+        {
+          path: 'accounting/loans/new',
+          name: 'loan-new',
+          component: () => import('@/pages/accounting/loans/LoanFormPage.vue'),
+          meta: { breadcrumb: 'New Loan' }
+        },
+        {
+          path: 'accounting/loans/:id',
+          name: 'loan-detail',
+          component: () => import('@/pages/accounting/loans/LoanDetailPage.vue'),
+          meta: { breadcrumb: (route) => `Loan #${route.params.id}` }
+        },
+        {
+          path: 'accounting/loans/:id/edit',
+          name: 'loan-edit',
+          component: () => import('@/pages/accounting/loans/LoanFormPage.vue'),
+          meta: { breadcrumb: 'Edit Loan' }
+        },
+        {
+          path: 'accounting/loans-analysis',
+          name: 'loans-analysis',
+          component: () => import('@/pages/accounting/loans-analysis/LoansAnalysisPage.vue'),
+          meta: { breadcrumb: 'Loans Analysis' }
+        },
+        {
+          path: 'loans',
+          redirect: { name: 'loans' },
+        },
+        {
+          path: 'loans-analysis',
+          redirect: { name: 'loans-analysis' },
+        },
         // Accounting - Journal Entries routes
         {
           path: 'accounting/journal-entries',


### PR DESCRIPTION
## Summary
Add Accounting nav and pages for Odoo Loans and Loans Analysis (were 404). Confirm generates the amortization board and posts disbursement; post next installment from the loan detail. `/loans` and `/loans-analysis` redirect to the Accounting routes.

Companion API: `satriyop/enter365` (this issue’s BE PR).

Related to satriyop/enter365#143

## Test plan
- [x] vitest loans + nav
- [ ] After deploy: hard-refresh; Loans / Loans Analysis are not 404; Assets still present