### PR TITLE
feat(accounting): add Deferred Expenses and Deferred Revenues pages (#144)

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -2392,6 +2392,134 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/deferred-expenses": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["deferred-expenses.index"];
+        put?: never;
+        post: operations["deferred-expenses.store"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/deferred-expenses/{deferredEntry}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["deferred-expenses.show"];
+        put: operations["deferred-expenses.update"];
+        post?: never;
+        delete: operations["deferred-expenses.destroy"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/deferred-expenses/{deferredEntry}/confirm": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["deferredExpense.confirm"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/deferred-expenses/{deferredEntry}/post-recognition": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["deferredExpense.postRecognition"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/deferred-revenues": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["deferred-revenues.index"];
+        put?: never;
+        post: operations["deferred-revenues.store"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/deferred-revenues/{deferredEntry}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["deferred-revenues.show"];
+        put: operations["deferred-revenues.update"];
+        post?: never;
+        delete: operations["deferred-revenues.destroy"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/deferred-revenues/{deferredEntry}/confirm": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["deferredRevenue.confirm"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/deferred-revenues/{deferredEntry}/post-recognition": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["deferredRevenue.postRecognition"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/delivery-orders": {
         parameters: {
             query?: never;
@@ -9080,6 +9208,45 @@ export interface components {
             name?: string | null;
             is_primary_variant?: boolean | null;
         };
+        /** DeferredEntryLineResource */
+        DeferredEntryLineResource: {
+            id: number;
+            deferred_entry_id: string;
+            sequence: string;
+            recognition_date: string | null;
+            amount: string;
+            remaining_amount: string;
+            status: string;
+            journal_entry_id: string;
+            posted_at: string | null;
+        };
+        /** DeferredEntryResource */
+        DeferredEntryResource: {
+            id: number;
+            kind: string;
+            code: string;
+            name: string;
+            contact_id: string;
+            amount: string;
+            duration_months: string;
+            start_date: string | null;
+            deferred_account_id: string;
+            recognition_account_id: string;
+            counterpart_account_id: string;
+            journal_id: string;
+            status: string;
+            remaining_amount: string;
+            origination_journal_entry_id: string;
+            notes: string;
+            contact?: {
+                id: number;
+                code: string;
+                name: string;
+            } | null;
+            lines?: components["schemas"]["DeferredEntryLineResource"][];
+            created_at: string | null;
+            updated_at: string | null;
+        };
         /** DeliveryOrderItemResource */
         DeliveryOrderItemResource: {
             id: number;
@@ -9701,7 +9868,7 @@ export interface components {
         };
         /** LoanLineResource */
         LoanLineResource: {
-            id: string;
+            id: number;
             loan_id: string;
             sequence: string;
             due_date: string | null;
@@ -9715,7 +9882,7 @@ export interface components {
         };
         /** LoanResource */
         LoanResource: {
-            id: string;
+            id: number;
             code: string;
             name: string;
             contact_id: string;
@@ -11761,6 +11928,21 @@ export interface components {
             is_active?: boolean;
             fiscal_position_id?: number | null;
         };
+        /** StoreDeferredEntryRequest */
+        StoreDeferredEntryRequest: {
+            code: string;
+            name: string;
+            contact_id?: number | null;
+            amount: number;
+            duration_months: number;
+            /** Format: date-time */
+            start_date: string;
+            deferred_account_id: number;
+            recognition_account_id: number;
+            counterpart_account_id: number;
+            journal_id?: number | null;
+            notes?: string | null;
+        };
         /** StoreDeliveryOrderRequest */
         StoreDeliveryOrderRequest: {
             invoice_id?: number | null;
@@ -13013,6 +13195,21 @@ export interface components {
             notes?: string | null;
             is_active?: boolean;
             fiscal_position_id?: number | null;
+        };
+        /** UpdateDeferredEntryRequest */
+        UpdateDeferredEntryRequest: {
+            code?: string;
+            name?: string;
+            contact_id?: number | null;
+            amount?: number;
+            duration_months?: number;
+            /** Format: date-time */
+            start_date?: string;
+            deferred_account_id?: number;
+            recognition_account_id?: number;
+            counterpart_account_id?: number;
+            journal_id?: number | null;
+            notes?: string | null;
         };
         /** UpdateDeliveryOrderRequest */
         UpdateDeliveryOrderRequest: {
@@ -20632,6 +20829,456 @@ export interface operations {
             };
             401: components["responses"]["AuthenticationException"];
             403: components["responses"]["AuthorizationException"];
+        };
+    };
+    "deferred-expenses.index": {
+        parameters: {
+            query?: {
+                per_page?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Paginated set of `DeferredEntryResource` */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data: (components["schemas"]["DeferredEntryResource"] & Record<string, never>)[];
+                        links: {
+                            first: string | null;
+                            last: string | null;
+                            prev: string | null;
+                            next: string | null;
+                        };
+                        meta: {
+                            current_page: number;
+                            from: number | null;
+                            last_page: number;
+                            /** @description Generated paginator links. */
+                            links: {
+                                url: string | null;
+                                label: string;
+                                active: boolean;
+                            }[];
+                            /** @description Base path for paginator generated URLs. */
+                            path: string | null;
+                            /** @description Number of items shown per page. */
+                            per_page: number;
+                            /** @description Number of the last item in the slice. */
+                            to: number | null;
+                            /** @description Total number of items being paginated. */
+                            total: number;
+                        };
+                    };
+                };
+            };
+            401: components["responses"]["AuthenticationException"];
+            403: components["responses"]["AuthorizationException"];
+        };
+    };
+    "deferred-expenses.store": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["StoreDeferredEntryRequest"];
+            };
+        };
+        responses: {
+            /** @description `DeferredEntryResource` */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data: components["schemas"]["DeferredEntryResource"] & Record<string, never>;
+                    };
+                };
+            };
+            401: components["responses"]["AuthenticationException"];
+            403: components["responses"]["AuthorizationException"];
+            422: components["responses"]["ValidationException"];
+        };
+    };
+    "deferred-expenses.show": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The deferred entry ID */
+                deferredEntry: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description `DeferredEntryResource` */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data: components["schemas"]["DeferredEntryResource"] & Record<string, never>;
+                    };
+                };
+            };
+            401: components["responses"]["AuthenticationException"];
+            403: components["responses"]["AuthorizationException"];
+            404: components["responses"]["ModelNotFoundException"];
+        };
+    };
+    "deferred-expenses.update": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The deferred entry ID */
+                deferredEntry: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["UpdateDeferredEntryRequest"];
+            };
+        };
+        responses: {
+            /** @description `DeferredEntryResource` */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data: components["schemas"]["DeferredEntryResource"];
+                    };
+                };
+            };
+            401: components["responses"]["AuthenticationException"];
+            403: components["responses"]["AuthorizationException"];
+            404: components["responses"]["ModelNotFoundException"];
+            422: components["responses"]["ValidationException"];
+        };
+    };
+    "deferred-expenses.destroy": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The deferred entry ID */
+                deferredEntry: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        success: boolean;
+                        /** @constant */
+                        message: "Biaya tangguhan berhasil dihapus.";
+                    };
+                };
+            };
+            401: components["responses"]["AuthenticationException"];
+            403: components["responses"]["AuthorizationException"];
+            404: components["responses"]["ModelNotFoundException"];
+        };
+    };
+    "deferredExpense.confirm": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The deferred entry ID */
+                deferredEntry: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description `DeferredEntryResource` */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data: components["schemas"]["DeferredEntryResource"];
+                    };
+                };
+            };
+            401: components["responses"]["AuthenticationException"];
+            403: components["responses"]["AuthorizationException"];
+            404: components["responses"]["ModelNotFoundException"];
+        };
+    };
+    "deferredExpense.postRecognition": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The deferred entry ID */
+                deferredEntry: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description `DeferredEntryResource` */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data: components["schemas"]["DeferredEntryResource"];
+                    };
+                };
+            };
+            401: components["responses"]["AuthenticationException"];
+            403: components["responses"]["AuthorizationException"];
+            404: components["responses"]["ModelNotFoundException"];
+        };
+    };
+    "deferred-revenues.index": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Paginated set of `DeferredEntryResource` */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data: (components["schemas"]["DeferredEntryResource"] & Record<string, never>)[];
+                        links: {
+                            first: string | null;
+                            last: string | null;
+                            prev: string | null;
+                            next: string | null;
+                        };
+                        meta: {
+                            current_page: number;
+                            from: number | null;
+                            last_page: number;
+                            /** @description Generated paginator links. */
+                            links: {
+                                url: string | null;
+                                label: string;
+                                active: boolean;
+                            }[];
+                            /** @description Base path for paginator generated URLs. */
+                            path: string | null;
+                            /** @description Number of items shown per page. */
+                            per_page: number;
+                            /** @description Number of the last item in the slice. */
+                            to: number | null;
+                            /** @description Total number of items being paginated. */
+                            total: number;
+                        };
+                    };
+                };
+            };
+            401: components["responses"]["AuthenticationException"];
+            403: components["responses"]["AuthorizationException"];
+        };
+    };
+    "deferred-revenues.store": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["StoreDeferredEntryRequest"];
+            };
+        };
+        responses: {
+            /** @description `DeferredEntryResource` */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data: components["schemas"]["DeferredEntryResource"] & Record<string, never>;
+                    };
+                };
+            };
+            401: components["responses"]["AuthenticationException"];
+            403: components["responses"]["AuthorizationException"];
+            422: components["responses"]["ValidationException"];
+        };
+    };
+    "deferred-revenues.show": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The deferred entry ID */
+                deferredEntry: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description `DeferredEntryResource` */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data: components["schemas"]["DeferredEntryResource"] & Record<string, never>;
+                    };
+                };
+            };
+            401: components["responses"]["AuthenticationException"];
+            403: components["responses"]["AuthorizationException"];
+            404: components["responses"]["ModelNotFoundException"];
+        };
+    };
+    "deferred-revenues.update": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The deferred entry ID */
+                deferredEntry: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["UpdateDeferredEntryRequest"];
+            };
+        };
+        responses: {
+            /** @description `DeferredEntryResource` */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data: components["schemas"]["DeferredEntryResource"];
+                    };
+                };
+            };
+            401: components["responses"]["AuthenticationException"];
+            403: components["responses"]["AuthorizationException"];
+            404: components["responses"]["ModelNotFoundException"];
+            422: components["responses"]["ValidationException"];
+        };
+    };
+    "deferred-revenues.destroy": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The deferred entry ID */
+                deferredEntry: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        success: boolean;
+                        /** @constant */
+                        message: "Pendapatan tangguhan berhasil dihapus.";
+                    };
+                };
+            };
+            401: components["responses"]["AuthenticationException"];
+            403: components["responses"]["AuthorizationException"];
+            404: components["responses"]["ModelNotFoundException"];
+        };
+    };
+    "deferredRevenue.confirm": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The deferred entry ID */
+                deferredEntry: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description `DeferredEntryResource` */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data: components["schemas"]["DeferredEntryResource"];
+                    };
+                };
+            };
+            401: components["responses"]["AuthenticationException"];
+            403: components["responses"]["AuthorizationException"];
+            404: components["responses"]["ModelNotFoundException"];
+        };
+    };
+    "deferredRevenue.postRecognition": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The deferred entry ID */
+                deferredEntry: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description `DeferredEntryResource` */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data: components["schemas"]["DeferredEntryResource"];
+                    };
+                };
+            };
+            401: components["responses"]["AuthenticationException"];
+            403: components["responses"]["AuthorizationException"];
+            404: components["responses"]["ModelNotFoundException"];
         };
     };
     "delivery-orders.index": {

--- a/src/api/useDeferredEntries.ts
+++ b/src/api/useDeferredEntries.ts
@@ -1,0 +1,133 @@
+import { useMutation, useQueryClient } from '@tanstack/vue-query'
+import { createCrudHooks } from './factory'
+import { api } from './client'
+
+export type DeferredKind = 'expense' | 'revenue'
+export type DeferredStatus = 'draft' | 'running' | 'closed'
+export type DeferredLineStatus = 'draft' | 'posted'
+
+export interface DeferredEntryLine {
+  id: number
+  deferred_entry_id: number
+  sequence: number
+  recognition_date: string
+  amount: number
+  remaining_amount: number
+  status: DeferredLineStatus
+  journal_entry_id?: number | null
+  posted_at?: string | null
+}
+
+export interface DeferredEntry {
+  id: number
+  kind: DeferredKind
+  code: string
+  name: string
+  contact_id?: number | null
+  amount: number
+  duration_months: number
+  start_date: string
+  deferred_account_id: number
+  recognition_account_id: number
+  counterpart_account_id: number
+  journal_id?: number | null
+  status: DeferredStatus
+  remaining_amount: number
+  origination_journal_entry_id?: number | null
+  notes?: string | null
+  contact?: { id: number; code: string; name: string } | null
+  lines?: DeferredEntryLine[]
+}
+
+export interface DeferredEntryFilters {
+  page?: number
+  per_page?: number
+  search?: string
+  status?: string
+}
+
+export interface CreateDeferredEntryData {
+  code: string
+  name: string
+  contact_id?: number | null
+  amount: number
+  duration_months: number
+  start_date: string
+  deferred_account_id: number
+  recognition_account_id: number
+  counterpart_account_id: number
+  journal_id?: number | null
+  notes?: string | null
+}
+
+export type UpdateDeferredEntryData = Partial<CreateDeferredEntryData>
+
+export function deferredResource(kind: DeferredKind): string {
+  return kind === 'expense' ? 'deferred-expenses' : 'deferred-revenues'
+}
+
+export function deferredBasePath(kind: DeferredKind): string {
+  return kind === 'expense' ? '/accounting/deferred-expenses' : '/accounting/deferred-revenues'
+}
+
+export function deferredLabel(kind: DeferredKind): string {
+  return kind === 'expense' ? 'Deferred Expenses' : 'Deferred Revenues'
+}
+
+const expenseHooks = createCrudHooks<DeferredEntry, DeferredEntryFilters, CreateDeferredEntryData, UpdateDeferredEntryData>({
+  resourceName: 'deferred-expenses',
+  singularName: 'deferred-expense',
+})
+
+const revenueHooks = createCrudHooks<DeferredEntry, DeferredEntryFilters, CreateDeferredEntryData, UpdateDeferredEntryData>({
+  resourceName: 'deferred-revenues',
+  singularName: 'deferred-revenue',
+})
+
+function hooksFor(kind: DeferredKind) {
+  return kind === 'expense' ? expenseHooks : revenueHooks
+}
+
+export function useDeferredEntries(kind: DeferredKind) {
+  return hooksFor(kind).useList
+}
+
+export function useDeferredEntry(kind: DeferredKind) {
+  return hooksFor(kind).useSingle
+}
+
+export function useCreateDeferredEntry(kind: DeferredKind) {
+  return hooksFor(kind).useCreate
+}
+
+export function useUpdateDeferredEntry(kind: DeferredKind) {
+  return hooksFor(kind).useUpdate
+}
+
+export function useConfirmDeferredEntry(kind: DeferredKind) {
+  const queryClient = useQueryClient()
+  const resource = deferredResource(kind)
+  return useMutation({
+    mutationFn: async (id: number | string) => {
+      const response = await api.post<{ data: DeferredEntry }>(`/${resource}/${id}/confirm`)
+      return response.data.data
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [resource] })
+    },
+  })
+}
+
+export function usePostDeferredRecognition(kind: DeferredKind) {
+  const queryClient = useQueryClient()
+  const resource = deferredResource(kind)
+  return useMutation({
+    mutationFn: async (id: number | string) => {
+      const response = await api.post<{ data: DeferredEntry }>(`/${resource}/${id}/post-recognition`)
+      return response.data.data
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [resource] })
+    },
+  })
+}

--- a/src/config/nav.ts
+++ b/src/config/nav.ts
@@ -91,6 +91,8 @@ export const navigation: NavGroup[] = [
       { name: 'Depreciation Schedule', path: '/accounting/depreciation-schedule', icon: '📉', permission: 'journals.view' },
       { name: 'Loans', path: '/accounting/loans', icon: '🏦', permission: 'journals.view' },
       { name: 'Loans Analysis', path: '/accounting/loans-analysis', icon: '📈', permission: 'journals.view' },
+      { name: 'Deferred Expenses', path: '/accounting/deferred-expenses', icon: '⏳', permission: 'journals.view' },
+      { name: 'Deferred Revenues', path: '/accounting/deferred-revenues', icon: '📥', permission: 'journals.view' },
       { name: 'Journal Entries', path: '/accounting/journal-entries', icon: '📝', permission: 'journals.view' },
       { name: 'Fiscal Periods', path: '/accounting/fiscal-periods', icon: '📅', permission: 'fiscal_periods.view' },
       { name: 'Budgets', path: '/accounting/budgets', icon: '📊', permission: 'budgets.view', feature: 'budgeting' },

--- a/src/layouts/AppLayout.vue
+++ b/src/layouts/AppLayout.vue
@@ -56,9 +56,9 @@ function closeSidebar() {
         <Breadcrumbs />
 
         <!-- Route Transition -->
-        <RouterView v-slot="{ Component }">
+        <RouterView v-slot="{ Component, route }">
           <Transition name="fade" mode="out-in">
-            <component :is="Component" />
+            <component :is="Component" :key="String(route.name)" />
           </Transition>
         </RouterView>
       </main>

--- a/src/layouts/AppSidebar.vue
+++ b/src/layouts/AppSidebar.vue
@@ -136,7 +136,11 @@ onBeforeUnmount(stopNavRescue)
                       ? 'sidebar-loans'
                       : item.path === '/accounting/loans-analysis'
                         ? 'sidebar-loans-analysis'
-                        : undefined"
+                        : item.path === '/accounting/deferred-expenses'
+                          ? 'sidebar-deferred-expenses'
+                          : item.path === '/accounting/deferred-revenues'
+                            ? 'sidebar-deferred-revenues'
+                            : undefined"
           data-rescue="nav"
           class="flex items-center gap-3 px-4 py-2.5 mx-2 rounded-lg text-sm font-medium transition-colors"
           :class="[

--- a/src/pages/accounting/deferred-entries/DeferredEntryDetailPage.vue
+++ b/src/pages/accounting/deferred-entries/DeferredEntryDetailPage.vue
@@ -1,0 +1,125 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import {
+  deferredBasePath,
+  deferredLabel,
+  useConfirmDeferredEntry,
+  useDeferredEntry,
+  usePostDeferredRecognition,
+  type DeferredKind,
+} from '@/api/useDeferredEntries'
+import { formatCurrency, formatDate } from '@/utils/format'
+import { Button, Card, ResponsiveTable, useToast, type ResponsiveColumn } from '@/components/ui'
+import { ArrowLeft } from 'lucide-vue-next'
+
+const route = useRoute()
+const router = useRouter()
+const toast = useToast()
+const kind = computed<DeferredKind>(() => (route.meta.kind === 'revenue' ? 'revenue' : 'expense'))
+const basePath = computed(() => deferredBasePath(kind.value))
+const title = computed(() => deferredLabel(kind.value))
+const entryId = computed(() => String(route.params.id ?? ''))
+const { data: entry, isLoading, error } = useDeferredEntry(kind.value)(entryId)
+const confirmMutation = useConfirmDeferredEntry(kind.value)
+const postMutation = usePostDeferredRecognition(kind.value)
+
+const columns: ResponsiveColumn[] = [
+  { key: 'sequence', label: '#', mobilePriority: 1 },
+  { key: 'recognition_date', label: 'Date', mobilePriority: 2 },
+  { key: 'amount', label: 'Amount', mobilePriority: 3 },
+  { key: 'remaining_amount', label: 'Remaining', showInMobile: false },
+  { key: 'status', label: 'Status', mobilePriority: 4 },
+]
+
+async function confirm() {
+  try {
+    await confirmMutation.mutateAsync(entryId.value)
+    toast.success('Entry confirmed and schedule generated')
+  } catch {
+    toast.error('Failed to confirm entry')
+  }
+}
+
+async function postNext() {
+  try {
+    await postMutation.mutateAsync(entryId.value)
+    toast.success('Recognition posted')
+  } catch {
+    toast.error('Failed to post recognition')
+  }
+}
+
+function editEntry() {
+  router.push(basePath.value + '/' + entryId.value + '/edit')
+}
+
+function goList() {
+  router.push(basePath.value)
+}
+</script>
+
+<template>
+  <div>
+    <div class="flex items-center gap-2 text-sm text-slate-500 mb-4">
+      <button type="button" class="hover:text-slate-700 flex items-center gap-1" @click="goList">
+        <ArrowLeft class="w-4 h-4" />
+        {{ title }}
+      </button>
+    </div>
+
+    <div v-if="error" class="text-red-500">Failed to load entry</div>
+    <div v-else-if="isLoading || !entry" class="text-slate-500">Loading…</div>
+    <template v-else>
+      <div class="flex items-center justify-between mb-6">
+        <div>
+          <h1 class="text-2xl font-semibold">{{ entry.code }} · {{ entry.name }}</h1>
+          <p class="text-slate-500">{{ entry.status }} · remaining {{ formatCurrency(entry.remaining_amount) }}</p>
+        </div>
+        <div class="flex gap-2">
+          <Button v-if="entry.status === 'draft'" variant="secondary" @click="editEntry">
+            Edit
+          </Button>
+          <Button v-if="entry.status === 'draft'" data-testid="deferred-confirm" @click="confirm">
+            Confirm
+          </Button>
+          <Button v-if="entry.status === 'running'" data-testid="deferred-post-recognition" @click="postNext">
+            Post next recognition
+          </Button>
+        </div>
+      </div>
+
+      <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
+        <Card class="p-4">
+          <div class="text-sm text-slate-500">Amount</div>
+          <div class="font-semibold">{{ formatCurrency(entry.amount) }}</div>
+        </Card>
+        <Card class="p-4">
+          <div class="text-sm text-slate-500">Duration</div>
+          <div class="font-semibold">{{ entry.duration_months }} months</div>
+        </Card>
+        <Card class="p-4">
+          <div class="text-sm text-slate-500">Start</div>
+          <div class="font-semibold">{{ formatDate(entry.start_date) }}</div>
+        </Card>
+      </div>
+
+      <Card>
+        <div class="p-4 font-semibold">Recognition schedule</div>
+        <div v-if="!entry.lines?.length" class="py-8 text-center text-slate-500">
+          Confirm the entry to generate the schedule and post origination.
+        </div>
+        <ResponsiveTable
+          v-else
+          :items="entry.lines"
+          :columns="columns"
+          row-key="id"
+        >
+          <template #cell-recognition_date="{ item }">{{ formatDate(item.recognition_date) }}</template>
+          <template #cell-amount="{ item }">{{ formatCurrency(item.amount) }}</template>
+          <template #cell-remaining_amount="{ item }">{{ formatCurrency(item.remaining_amount) }}</template>
+        </ResponsiveTable>
+      </Card>
+    </template>
+  </div>
+</template>

--- a/src/pages/accounting/deferred-entries/DeferredEntryFormPage.vue
+++ b/src/pages/accounting/deferred-entries/DeferredEntryFormPage.vue
@@ -1,0 +1,157 @@
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { useAccountsLookup } from '@/api/useAccounts'
+import {
+  deferredBasePath,
+  deferredLabel,
+  useCreateDeferredEntry,
+  useDeferredEntry,
+  useUpdateDeferredEntry,
+  type DeferredKind,
+} from '@/api/useDeferredEntries'
+import { Button, Card, Input, Select, useToast } from '@/components/ui'
+import { ArrowLeft } from 'lucide-vue-next'
+
+const route = useRoute()
+const router = useRouter()
+const toast = useToast()
+
+const kind = computed<DeferredKind>(() => (route.meta.kind === 'revenue' ? 'revenue' : 'expense'))
+const basePath = computed(() => deferredBasePath(kind.value))
+const title = computed(() => deferredLabel(kind.value))
+const entryId = computed(() => (route.params.id ? String(route.params.id) : ''))
+const isEditing = computed(() => !!entryId.value)
+
+const { data: existing } = useDeferredEntry(kind.value)(entryId)
+const { data: assetAccounts } = useAccountsLookup('asset')
+const { data: liabilityAccounts } = useAccountsLookup('liability')
+const { data: expenseAccounts } = useAccountsLookup('expense')
+const { data: revenueAccounts } = useAccountsLookup('revenue')
+
+const code = ref('')
+const name = ref('')
+const amount = ref('')
+const durationMonths = ref('12')
+const startDate = ref(new Date().toISOString().slice(0, 10))
+const deferredAccountId = ref('')
+const recognitionAccountId = ref('')
+const counterpartAccountId = ref('')
+
+watch(existing, (entry) => {
+  if (!entry) return
+  code.value = entry.code
+  name.value = entry.name
+  amount.value = String(entry.amount)
+  durationMonths.value = String(entry.duration_months)
+  startDate.value = entry.start_date
+  deferredAccountId.value = String(entry.deferred_account_id)
+  recognitionAccountId.value = String(entry.recognition_account_id)
+  counterpartAccountId.value = String(entry.counterpart_account_id)
+}, { immediate: true })
+
+function toAccountOptions(accounts: { id: number; code: string; name: string }[] | undefined) {
+  return (accounts ?? []).map((account) => ({
+    value: String(account.id),
+    label: account.code + ' · ' + account.name,
+  }))
+}
+
+const deferredOptions = computed(() =>
+  toAccountOptions(kind.value === 'expense' ? assetAccounts.value : liabilityAccounts.value),
+)
+const recognitionOptions = computed(() =>
+  toAccountOptions(kind.value === 'expense' ? expenseAccounts.value : revenueAccounts.value),
+)
+const counterpartOptions = computed(() => toAccountOptions(assetAccounts.value))
+
+const createMutation = useCreateDeferredEntry(kind.value)
+const updateMutation = useUpdateDeferredEntry(kind.value)
+
+function goBack() {
+  if (isEditing.value) {
+    router.push(basePath.value + '/' + entryId.value)
+    return
+  }
+  router.push(basePath.value)
+}
+
+async function handleSubmit() {
+  if (!code.value.trim() || !name.value.trim() || !amount.value) {
+    toast.error('Code, name, and amount are required')
+    return
+  }
+  if (!deferredAccountId.value || !recognitionAccountId.value || !counterpartAccountId.value) {
+    toast.error('Deferred, recognition, and bank accounts are required')
+    return
+  }
+
+  const payload = {
+    code: code.value.trim(),
+    name: name.value.trim(),
+    amount: Number(amount.value),
+    duration_months: Number(durationMonths.value),
+    start_date: startDate.value,
+    deferred_account_id: Number(deferredAccountId.value),
+    recognition_account_id: Number(recognitionAccountId.value),
+    counterpart_account_id: Number(counterpartAccountId.value),
+  }
+
+  try {
+    if (isEditing.value) {
+      await updateMutation.mutateAsync({ id: entryId.value, data: payload })
+      toast.success(title.value.slice(0, -1) + ' updated')
+      router.push(basePath.value + '/' + entryId.value)
+    } else {
+      const created = await createMutation.mutateAsync(payload)
+      toast.success(title.value.slice(0, -1) + ' created')
+      router.push(basePath.value + '/' + created.id)
+    }
+  } catch {
+    toast.error('Failed to save entry')
+  }
+}
+</script>
+
+<template>
+  <div>
+    <div class="flex items-center gap-2 text-sm text-slate-500 mb-4">
+      <button type="button" class="hover:text-slate-700 flex items-center gap-1" @click="goBack">
+        <ArrowLeft class="w-4 h-4" />
+        {{ title }}
+      </button>
+    </div>
+    <h1 class="text-2xl font-semibold mb-6">{{ isEditing ? 'Edit' : 'New' }} {{ kind === 'expense' ? 'Deferred Expense' : 'Deferred Revenue' }}</h1>
+    <form class="max-w-xl space-y-4" @submit.prevent="handleSubmit">
+      <Card class="space-y-4 p-4">
+        <Input v-model="code" data-testid="deferred-code" placeholder="Code" />
+        <Input v-model="name" data-testid="deferred-name" placeholder="Name" />
+        <Input v-model="amount" type="number" min="1" data-testid="deferred-amount" placeholder="Amount" />
+        <Input v-model="durationMonths" type="number" min="1" data-testid="deferred-duration" placeholder="Duration (months)" />
+        <Input v-model="startDate" type="date" data-testid="deferred-start-date" />
+        <Select
+          :model-value="deferredAccountId"
+          :options="deferredOptions"
+          :placeholder="kind === 'expense' ? 'Prepaid / deferred asset' : 'Unearned / deferred liability'"
+          test-id="deferred-account"
+          @update:model-value="(v) => { deferredAccountId = v ? String(v) : '' }"
+        />
+        <Select
+          :model-value="recognitionAccountId"
+          :options="recognitionOptions"
+          :placeholder="kind === 'expense' ? 'Expense account' : 'Revenue account'"
+          test-id="deferred-recognition-account"
+          @update:model-value="(v) => { recognitionAccountId = v ? String(v) : '' }"
+        />
+        <Select
+          :model-value="counterpartAccountId"
+          :options="counterpartOptions"
+          placeholder="Bank / cash account"
+          test-id="deferred-counterpart-account"
+          @update:model-value="(v) => { counterpartAccountId = v ? String(v) : '' }"
+        />
+      </Card>
+      <Button type="submit" data-testid="deferred-save">Save</Button>
+    </form>
+  </div>
+</template>

--- a/src/pages/accounting/deferred-entries/DeferredEntryListPage.vue
+++ b/src/pages/accounting/deferred-entries/DeferredEntryListPage.vue
@@ -1,0 +1,100 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import {
+  deferredBasePath,
+  deferredLabel,
+  useDeferredEntries,
+  type DeferredEntry,
+  type DeferredEntryFilters,
+  type DeferredKind,
+} from '@/api/useDeferredEntries'
+import { useResourceList } from '@/composables/useResourceList'
+import { formatCurrency, formatDate } from '@/utils/format'
+import { Button, Card, Input, ResponsiveTable, type ResponsiveColumn } from '@/components/ui'
+import { Plus, Search } from 'lucide-vue-next'
+
+const route = useRoute()
+const router = useRouter()
+const kind = computed<DeferredKind>(() => (route.meta.kind === 'revenue' ? 'revenue' : 'expense'))
+const basePath = computed(() => deferredBasePath(kind.value))
+const title = computed(() => deferredLabel(kind.value))
+
+const {
+  items,
+  isLoading,
+  error,
+  isEmpty,
+  filters,
+  updateFilter,
+} = useResourceList<DeferredEntry, DeferredEntryFilters>({
+  useListHook: useDeferredEntries(kind.value),
+  initialFilters: { page: 1, per_page: 50, search: '' },
+})
+
+const columns: ResponsiveColumn[] = [
+  { key: 'code', label: 'Code', mobilePriority: 1 },
+  { key: 'name', label: 'Name', mobilePriority: 2 },
+  { key: 'amount', label: 'Amount', mobilePriority: 3 },
+  { key: 'remaining_amount', label: 'Remaining', mobilePriority: 4 },
+  { key: 'status', label: 'Status', showInMobile: false },
+  { key: 'start_date', label: 'Start', showInMobile: false },
+]
+
+function openEntry(entry: DeferredEntry) {
+  router.push(basePath.value + '/' + entry.id)
+}
+
+function createEntry() {
+  router.push(basePath.value + '/new')
+}
+</script>
+
+<template>
+  <div>
+    <div class="flex items-center justify-between mb-6">
+      <div>
+        <h1 class="text-2xl font-semibold text-slate-900 dark:text-slate-100">{{ title }}</h1>
+        <p class="text-slate-500 dark:text-slate-400">
+          Confirm to generate the recognition schedule and post the origination journal.
+        </p>
+      </div>
+      <Button data-testid="deferred-create" @click="createEntry">
+        <Plus class="w-4 h-4 mr-1" />
+        New {{ kind === 'expense' ? 'Deferred Expense' : 'Deferred Revenue' }}
+      </Button>
+    </div>
+
+    <Card class="mb-4">
+      <div class="p-4">
+        <div class="relative">
+          <Search class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400" />
+          <Input
+            :model-value="filters.search ?? ''"
+            class="pl-9"
+            placeholder="Search code or name..."
+            data-testid="deferred-search"
+            @update:model-value="(v) => updateFilter('search', String(v))"
+          />
+        </div>
+      </div>
+    </Card>
+
+    <Card>
+      <div v-if="error" class="py-12 text-center text-red-500">Failed to load {{ title.toLowerCase() }}</div>
+      <div v-else-if="isEmpty && !isLoading" class="py-12 text-center text-slate-500">No entries found</div>
+      <ResponsiveTable
+        v-else
+        :items="items ?? []"
+        :columns="columns"
+        :loading="isLoading"
+        row-key="id"
+        @row-click="openEntry"
+      >
+        <template #cell-amount="{ item }">{{ formatCurrency(item.amount) }}</template>
+        <template #cell-remaining_amount="{ item }">{{ formatCurrency(item.remaining_amount) }}</template>
+        <template #cell-start_date="{ item }">{{ formatDate(item.start_date) }}</template>
+      </ResponsiveTable>
+    </Card>
+  </div>
+</template>

--- a/src/pages/accounting/deferred-entries/__tests__/deferredEntries.test.ts
+++ b/src/pages/accounting/deferred-entries/__tests__/deferredEntries.test.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+describe('deferred expenses and revenues (#144)', () => {
+  it('exposes Deferred Expenses and Deferred Revenues distinct from Loans', () => {
+    const nav = readFileSync(resolve(__dirname, '../../../../config/nav.ts'), 'utf8')
+    const router = readFileSync(resolve(__dirname, '../../../../router/index.ts'), 'utf8')
+    const sidebar = readFileSync(resolve(__dirname, '../../../../layouts/AppSidebar.vue'), 'utf8')
+    const list = readFileSync(resolve(__dirname, '../DeferredEntryListPage.vue'), 'utf8')
+    const detail = readFileSync(resolve(__dirname, '../DeferredEntryDetailPage.vue'), 'utf8')
+    const form = readFileSync(resolve(__dirname, '../DeferredEntryFormPage.vue'), 'utf8')
+    const api = readFileSync(resolve(__dirname, '../../../../api/useDeferredEntries.ts'), 'utf8')
+
+    expect(nav).toContain("name: 'Deferred Expenses'")
+    expect(nav).toContain('/accounting/deferred-expenses')
+    expect(nav).toContain("name: 'Deferred Revenues'")
+    expect(nav).toContain('/accounting/deferred-revenues')
+    expect(router).toContain("path: 'accounting/deferred-expenses'")
+    expect(router).toContain("path: 'accounting/deferred-revenues'")
+    expect(router).toContain("path: 'deferred-expenses'")
+    expect(router).toContain("path: 'deferred-revenues'")
+    expect(sidebar).toContain('sidebar-deferred-expenses')
+    expect(sidebar).toContain('sidebar-deferred-revenues')
+    expect(list).toContain('New {{ kind === \'expense\' ? \'Deferred Expense\' : \'Deferred Revenue\' }}')
+    expect(api).toContain('useConfirmDeferredEntry')
+    expect(api).toContain('usePostDeferredRecognition')
+    expect(api).toContain('/post-recognition')
+    expect(detail).not.toContain('router.push(`')
+    expect(form).not.toContain('router.push(`')
+    expect(list).not.toContain('router.push(`')
+    expect(detail).toContain('editEntry')
+  })
+})

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -742,6 +742,62 @@ const router = createRouter({
           path: 'loans-analysis',
           redirect: { name: 'loans-analysis' },
         },
+        {
+          path: 'accounting/deferred-expenses',
+          name: 'deferred-expenses',
+          component: () => import('@/pages/accounting/deferred-entries/DeferredEntryListPage.vue'),
+          meta: { breadcrumb: 'Deferred Expenses', kind: 'expense' }
+        },
+        {
+          path: 'accounting/deferred-expenses/new',
+          name: 'deferred-expense-new',
+          component: () => import('@/pages/accounting/deferred-entries/DeferredEntryFormPage.vue'),
+          meta: { breadcrumb: 'New Deferred Expense', kind: 'expense' }
+        },
+        {
+          path: 'accounting/deferred-expenses/:id',
+          name: 'deferred-expense-detail',
+          component: () => import('@/pages/accounting/deferred-entries/DeferredEntryDetailPage.vue'),
+          meta: { breadcrumb: (route) => `Deferred Expense #${route.params.id}`, kind: 'expense' }
+        },
+        {
+          path: 'accounting/deferred-expenses/:id/edit',
+          name: 'deferred-expense-edit',
+          component: () => import('@/pages/accounting/deferred-entries/DeferredEntryFormPage.vue'),
+          meta: { breadcrumb: 'Edit Deferred Expense', kind: 'expense' }
+        },
+        {
+          path: 'accounting/deferred-revenues',
+          name: 'deferred-revenues',
+          component: () => import('@/pages/accounting/deferred-entries/DeferredEntryListPage.vue'),
+          meta: { breadcrumb: 'Deferred Revenues', kind: 'revenue' }
+        },
+        {
+          path: 'accounting/deferred-revenues/new',
+          name: 'deferred-revenue-new',
+          component: () => import('@/pages/accounting/deferred-entries/DeferredEntryFormPage.vue'),
+          meta: { breadcrumb: 'New Deferred Revenue', kind: 'revenue' }
+        },
+        {
+          path: 'accounting/deferred-revenues/:id',
+          name: 'deferred-revenue-detail',
+          component: () => import('@/pages/accounting/deferred-entries/DeferredEntryDetailPage.vue'),
+          meta: { breadcrumb: (route) => `Deferred Revenue #${route.params.id}`, kind: 'revenue' }
+        },
+        {
+          path: 'accounting/deferred-revenues/:id/edit',
+          name: 'deferred-revenue-edit',
+          component: () => import('@/pages/accounting/deferred-entries/DeferredEntryFormPage.vue'),
+          meta: { breadcrumb: 'Edit Deferred Revenue', kind: 'revenue' }
+        },
+        {
+          path: 'deferred-expenses',
+          redirect: { name: 'deferred-expenses' },
+        },
+        {
+          path: 'deferred-revenues',
+          redirect: { name: 'deferred-revenues' },
+        },
         // Accounting - Journal Entries routes
         {
           path: 'accounting/journal-entries',


### PR DESCRIPTION
## Summary
Add Accounting nav and pages for Odoo Deferred Expenses and Deferred Revenues (were 404). Confirm generates the recognition board and posts origination; post next recognition from the detail. `/deferred-expenses` and `/deferred-revenues` redirect to the Accounting routes.

Companion API: `satriyop/enter365` (this issue’s BE PR).

Related to satriyop/enter365#144

## Test plan
- [x] vitest deferredEntries + nav
- [ ] After deploy: hard-refresh; Deferred Expenses / Deferred Revenues are not 404; Loans still present